### PR TITLE
🔧 Trigger CI/CD on all branches for immediate feedback

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -2,7 +2,7 @@ name: CI/CD Pipeline
 
 on:
   push:
-    branches: [ main, develop ]
+    branches: [ '**' ]  # Toutes les branches pour feedback immédiat
   pull_request:
     branches: [ main ]
 

--- a/docs/dev/development.md
+++ b/docs/dev/development.md
@@ -43,7 +43,7 @@ back-office-lmelp/
 ### Backend (FastAPI)
 ```bash
 # Lancer le serveur de développement
-PYTHONPATH=/workspaces/back-office-lmelp/src API_PORT=54322 python -m back_office_lmelp.app
+PYTHONPATH=/workspaces/back-office-lmelp/src python -m back_office_lmelp.app
 
 # Tests
 uv run pytest tests/ -v --cov=src
@@ -82,3 +82,27 @@ npm run build
 - **JavaScript** : Standard avec ESLint
 - **Tests** : Couverture minimale 40%
 - **Documentation** : Docstrings obligatoires
+
+## CI/CD Pipeline
+
+### Déclencheurs
+
+Le pipeline CI/CD se déclenche automatiquement sur :
+- **Tous les pushs** sur n'importe quelle branche (`branches: ['**']`)
+- **Pull requests** vers `main`
+
+Cette configuration offre un **feedback immédiat** sur chaque commit, permettant une détection précoce des régressions.
+
+### Jobs exécutés
+
+- ✅ **Tests backend** (Python 3.11 + 3.12)
+- ✅ **Tests frontend** (Node.js 18)
+- ✅ **Security scan** (detect-secrets)
+- ✅ **Quality gate** (validation de tous les jobs)
+- 🚀 **Déploiements** (uniquement sur `main`)
+
+### Optimisations
+
+- **Concurrence** : Isolation par branche (`cancel-in-progress: true`)
+- **Cache** : Dependencies Python (uv) et Node.js (npm)
+- **Déploiement conditionnel** : Staging/Production uniquement sur `main`

--- a/tests/test_workflow_triggers.py
+++ b/tests/test_workflow_triggers.py
@@ -1,0 +1,103 @@
+"""Tests pour vérifier les déclencheurs de workflows GitHub Actions."""
+
+from pathlib import Path
+
+import yaml
+
+
+def test_ci_cd_workflow_triggers_on_feature_branches():
+    """Test que le workflow CI/CD se déclenche sur les branches de feature."""
+    workflow_path = Path(".github/workflows/ci-cd.yml")
+    assert workflow_path.exists(), "Workflow CI/CD non trouvé"
+
+    with open(workflow_path) as f:
+        workflow = yaml.safe_load(f)
+
+    # Vérifier la structure "on.push.branches" (PyYAML parse 'on:' comme True)
+    on_section = workflow.get("on") or workflow.get(True)
+    assert on_section is not None, "Section 'on' manquante"
+    assert "push" in on_section, "Trigger 'push' manquant"
+
+    push_branches = on_section["push"]["branches"]
+
+    # Le workflow doit se déclencher sur toutes les branches
+    assert push_branches == ["**"], (
+        f"Branches push incorrectes: {push_branches}. Attendu: ['**']"
+    )
+
+
+def test_ci_cd_workflow_pr_triggers():
+    """Test que le workflow CI/CD garde les bons triggers pour les PR."""
+    workflow_path = Path(".github/workflows/ci-cd.yml")
+
+    with open(workflow_path) as f:
+        workflow = yaml.safe_load(f)
+
+    # PyYAML parse 'on:' comme True
+    on_section = workflow.get("on") or workflow.get(True)
+
+    # Les PR doivent toujours cibler main uniquement
+    pr_branches = on_section["pull_request"]["branches"]
+    assert pr_branches == ["main"], f"PR branches incorrectes: {pr_branches}"
+
+
+def test_docs_workflow_remains_selective():
+    """Test que le workflow docs reste sélectif (pas besoin de tourner sur toutes les branches)."""
+    workflow_path = Path(".github/workflows/docs.yml")
+
+    with open(workflow_path) as f:
+        workflow = yaml.safe_load(f)
+
+    # PyYAML parse 'on:' comme True
+    on_section = workflow.get("on") or workflow.get(True)
+
+    # Le workflow docs doit avoir des paths filter
+    assert "paths" in on_section["push"], "Filtre 'paths' manquant pour docs push"
+    assert "paths" in on_section["pull_request"], "Filtre 'paths' manquant pour docs PR"
+
+    # Et doit inclure les patterns de docs
+    push_paths = on_section["push"]["paths"]
+    assert "docs/**" in push_paths, "Pattern 'docs/**' manquant"
+    assert "mkdocs.yml" in push_paths, "Pattern 'mkdocs.yml' manquant"
+
+
+def test_deployment_jobs_only_on_main():
+    """Test que les déploiements ne se font que sur main."""
+    workflow_path = Path(".github/workflows/ci-cd.yml")
+
+    with open(workflow_path) as f:
+        workflow = yaml.safe_load(f)
+
+    deploy_jobs = [
+        job
+        for job_name, job in workflow["jobs"].items()
+        if job_name.startswith("deploy-")
+    ]
+
+    for job in deploy_jobs:
+        # Tous les jobs de déploiement doivent être conditionnés sur main
+        condition = job.get("if", "")
+        assert "refs/heads/main" in condition, (
+            f"Job de déploiement non conditionné sur main: {condition}"
+        )
+
+
+def test_concurrency_configuration():
+    """Test que la configuration de concurrence permet plusieurs branches."""
+    workflow_path = Path(".github/workflows/ci-cd.yml")
+
+    with open(workflow_path) as f:
+        workflow = yaml.safe_load(f)
+
+    # Vérifier la concurrence par branche/ref
+    concurrency = workflow.get("concurrency", {})
+    assert "group" in concurrency, "Configuration de concurrence manquante"
+
+    group = concurrency["group"]
+    # Doit inclure github.ref pour isoler par branche
+    assert "github.ref" in group, f"Concurrence mal configurée: {group}"
+
+    # cancel-in-progress doit être true pour éviter les runs multiples
+    assert concurrency.get("cancel-in-progress") is True, (
+        "cancel-in-progress devrait être True"
+    )


### PR DESCRIPTION
## 🎯 Summary

Resolves #10 - Configure CI/CD pipeline to trigger on **all branches** instead of just `main` and `develop`.

## 🔄 Changes Made

### Workflow Configuration
- Modified `.github/workflows/ci-cd.yml` to use `branches: ['**']` for push triggers  
- Maintains PR targeting to `main` only
- Deployments still restricted to `main` branch only

### Test Coverage  
- Added comprehensive test suite `tests/test_workflow_triggers.py` (5 tests)
- TDD approach: tests written first, then implementation
- Validates workflow triggers, PR configuration, deployment restrictions

### Documentation
- Updated `docs/dev/development.md` with CI/CD pipeline details
- Documented benefits and optimizations
- Removed outdated port references

## ✅ Benefits

- **Immediate feedback** on every commit (no more waiting for PR)
- **Early detection** of regressions and issues  
- **Improved developer experience** with rapid iteration
- **Better code quality** maintained throughout development
- **Secure deployments** (still main-only)

## 🧪 Test Plan

- [x] All existing tests pass (24 tests total)
- [x] New workflow trigger tests pass (5 tests)  
- [x] Linting and type checking clean
- [x] **Live validation**: This branch triggered CI/CD automatically! 🎉
- [x] User confirmed CI/CD working in GitHub interface

## 🔧 Technical Details

**Before**: 
```yaml
branches: [ main, develop ]
```

**After**:
```yaml  
branches: [ '**' ]  # All branches for immediate feedback
```

Deployments remain conditional on `main` branch to maintain production safety.

## 📊 Impact

- **Zero breaking changes** - all existing functionality preserved
- **Enhanced workflow** - developers get faster feedback  
- **Resource efficient** - proper concurrency management with `cancel-in-progress`
- **Battle tested** - comprehensive test coverage ensures reliability

🤖 Generated with [Claude Code](https://claude.ai/code)