### PR TITLE
fix(docker): use main() entrypoint and /health endpoint for healthchecks

### DIFF
--- a/docker/build/backend/Dockerfile
+++ b/docker/build/backend/Dockerfile
@@ -46,9 +46,9 @@ ENV MONGODB_URL=mongodb://mongo:27017/masque_et_la_plume
 # Expose port
 EXPOSE ${API_PORT}
 
-# Healthcheck
+# Healthcheck (Issue #115: Use dedicated /health endpoint)
 HEALTHCHECK --interval=30s --timeout=10s --start-period=5s --retries=3 \
-    CMD curl -f http://localhost:${API_PORT}/ || exit 1
+    CMD curl -f http://localhost:${API_PORT}/health || exit 1
 
-# Run the application
-CMD uvicorn back_office_lmelp.app:app --host ${API_HOST} --port ${API_PORT}
+# Run the application (Issue #115: Use main() to configure access_log=False)
+CMD ["python", "-m", "back_office_lmelp.app"]


### PR DESCRIPTION
## Résumé

Fix le problème de logs pollués par les healthchecks Docker qui persistait malgré l'implémentation du code de l'issue #115.

## Problème identifié

Le code de l'issue #115 avait été correctement implémenté (endpoint `/health` + middleware de logging enrichi), mais le Dockerfile n'utilisait pas la bonne configuration:

1. ❌ **CMD utilisait uvicorn directement**: `uvicorn back_office_lmelp.app:app` qui bypass la fonction `main()` où `access_log=False` est configuré
2. ❌ **HEALTHCHECK utilisait `/` au lieu de `/health`**: Les healthchecks Docker continuaient à frapper l'ancien endpoint

## Solution

### Modifications du Dockerfile

**Avant**:
```dockerfile
HEALTHCHECK CMD curl -f http://localhost:${API_PORT}/ || exit 1
CMD uvicorn back_office_lmelp.app:app --host ${API_HOST} --port ${API_PORT}
```

**Après**:
```dockerfile
# Healthcheck (Issue #115: Use dedicated /health endpoint)
HEALTHCHECK CMD curl -f http://localhost:${API_PORT}/health || exit 1

# Run the application (Issue #115: Use main() to configure access_log=False)
CMD ["python", "-m", "back_office_lmelp.app"]
```

## Résultats attendus

Après redéploiement de la nouvelle image Docker:

✅ **Logs propres**: Les requêtes `/health` ne sont plus loggées (filtrage par middleware)
✅ **Format enrichi**: Les vraies requêtes utilisateur ont le format enrichi avec timestamp ISO8601, user-agent, durée, etc.
✅ **Configuration correcte**: La fonction `main()` configure uvicorn avec `access_log=False`

**Format des logs attendu**:
```
2025-11-26T17:30:45+0000 "GET /api/episodes HTTP/1.1" 200 1523 0.045s "Mozilla/5.0 ..."
```

## Tests

- ✅ Tous les tests backend passent (11/11 pour health + logging middleware)
- ✅ CI/CD pipeline complet passé (Python 3.11 & 3.12, frontend, security)
- ✅ Lint et typecheck OK

## Déploiement

Une fois mergé, le workflow Docker Build publiera automatiquement la nouvelle image avec le tag `latest`. L'utilisateur devra ensuite recréer la stack dans Portainer pour appliquer les changements.

Closes #115

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude <noreply@anthropic.com>