### PR TITLE
Remove CALIBRE_LIBRARY_PATH and rely on /calibre mount point

### DIFF
--- a/docker/deployment/docker-compose.yml
+++ b/docker/deployment/docker-compose.yml
@@ -33,11 +33,10 @@ services:
 
       # Calibre integration (optionnel)
       # Si CALIBRE_HOST_PATH est défini dans .env, Calibre sera disponible à /calibre
-      CALIBRE_LIBRARY_PATH: ${CALIBRE_HOST_PATH:+/calibre}
       CALIBRE_VIRTUAL_LIBRARY_TAG: ${CALIBRE_VIRTUAL_LIBRARY_TAG:-}
 
     # Volumes
-    # Monter la bibliothèque Calibre si CALIBRE_LIBRARY_PATH est défini
+    # Monter la bibliothèque Calibre si CALIBRE_HOST_PATH est défini
     # Format : <chemin-hôte>:<chemin-conteneur>:ro
     # Exemple : /volume1/books/Calibre Library:/calibre:ro
     volumes:

--- a/docs/deployment/calibre-setup.md
+++ b/docs/deployment/calibre-setup.md
@@ -134,7 +134,7 @@ Vous devriez voir :
 
 ### Erreur : "Calibre non disponible"
 
-**Symptôme** : Message d'erreur dans l'interface web : "Calibre non disponible - CALIBRE_LIBRARY_PATH not configured"
+**Symptôme** : Message d'erreur dans l'interface web : "Bibliothèque Calibre non trouvée"
 
 **Solutions** :
 
@@ -143,7 +143,8 @@ Vous devriez voir :
    ```bash
    ls -l "/volume1/books/Calibre Library/metadata.db"
    ```
-3. Redéployez la stack après modification du `.env`
+3. Vérifiez que le volume est bien monté dans le conteneur (le dossier `/calibre` doit exister et contenir `metadata.db`).
+4. Redéployez la stack après modification du `.env`
 
 ### Erreur : "Permission denied"
 

--- a/docs/user/calibre-integration.md
+++ b/docs/user/calibre-integration.md
@@ -99,8 +99,8 @@ Une fois les données synchronisées, fonctionnalités planifiées :
 
 L'intégration Calibre n'est active que si :
 
-1. ✅ Variable d'environnement `CALIBRE_LIBRARY_PATH` définie
-2. ✅ Base de données Calibre accessible au chemin indiqué
+1. ✅ Le volume Docker est monté sur `/calibre`
+2. ✅ Base de données Calibre (`metadata.db`) accessible dans ce dossier
 3. ✅ Bibliothèque Calibre valide et lisible
 
 Si ces conditions ne sont pas remplies, la fonctionnalité reste invisible dans l'interface.
@@ -179,27 +179,22 @@ Dans la page de **recherche avancée**, nouveau champ :
 
 ## Configuration
 
-### Variable d'environnement
+### Montage du volume
+
+L'application détecte automatiquement la bibliothèque Calibre si elle est montée dans le dossier `/calibre`.
 
 ```bash
-# Développement local
-export CALIBRE_LIBRARY_PATH="/home/guillaume/Calibre Library"
-
 # Docker (docker-compose.yml)
-environment:
-  - CALIBRE_LIBRARY_PATH=/calibre-library
-
-# Docker volume mount
 volumes:
-  - /home/guillaume/Calibre Library:/calibre-library:ro
+  - /home/guillaume/Calibre Library:/calibre:ro
 ```
 
 ### Validation au démarrage
 
 Au démarrage, l'application :
 
-1. Vérifie l'existence de `CALIBRE_LIBRARY_PATH`
-2. Teste l'accès à la base Calibre (`metadata.db`)
+1. Vérifie l'existence du dossier `/calibre` et du fichier `metadata.db`
+2. Teste l'accès à la base Calibre
 3. Valide la structure de la bibliothèque
 4. Active/désactive l'intégration en conséquence
 
@@ -215,7 +210,7 @@ ou
 
 ```
 [WARNING] Calibre integration: DISABLED
-[WARNING] CALIBRE_LIBRARY_PATH not set
+[WARNING] Calibre library not found in /calibre
 ```
 
 ## Métadonnées Calibre utilisées

--- a/src/back_office_lmelp/services/calibre_service.py
+++ b/src/back_office_lmelp/services/calibre_service.py
@@ -66,12 +66,12 @@ class CalibreService:
         Returns:
             True si disponible, False sinon
         """
-        # Vérifier la variable d'environnement
+        # Vérifier la configuration
         library_path_str = settings.calibre_library_path
 
         if not library_path_str:
-            self._error = "Variable CALIBRE_LIBRARY_PATH non définie"
-            logger.info("Calibre non configuré (CALIBRE_LIBRARY_PATH manquant)")
+            self._error = "Bibliothèque Calibre non trouvée dans /calibre"
+            logger.info("Calibre non configuré (/calibre/metadata.db manquant)")
             return False
 
         # Vérifier le chemin

--- a/src/back_office_lmelp/settings.py
+++ b/src/back_office_lmelp/settings.py
@@ -26,9 +26,17 @@ class Settings:
         """
         Chemin vers la bibliothèque Calibre.
 
-        Si non défini ou vide, l'intégration Calibre est désactivée.
+        Vérifie si /calibre existe et contient metadata.db.
+        Si c'est le cas, retourne "/calibre".
+        Sinon, l'intégration Calibre est désactivée.
         """
-        return os.environ.get("CALIBRE_LIBRARY_PATH") or None
+        default_path = "/calibre"
+        if os.path.isdir(default_path) and os.path.isfile(
+            os.path.join(default_path, "metadata.db")
+        ):
+            return default_path
+
+        return None
 
     @property
     def calibre_virtual_library_tag(self) -> str | None:

--- a/tests/test_calibre_service.py
+++ b/tests/test_calibre_service.py
@@ -81,7 +81,7 @@ class TestCalibreServiceInitialization:
 
     @patch("back_office_lmelp.services.calibre_service.settings")
     def test_service_not_available_when_no_library_path(self, mock_settings):
-        """Service non disponible si CALIBRE_LIBRARY_PATH non définie."""
+        """Service non disponible si bibliothèque non trouvée."""
         mock_settings.calibre_library_path = None
         mock_settings.calibre_virtual_library_tag = None
 
@@ -90,7 +90,7 @@ class TestCalibreServiceInitialization:
         assert not service.is_available()
         status = service.get_status()
         assert not status.available
-        assert "CALIBRE_LIBRARY_PATH" in status.error
+        assert "Bibliothèque Calibre non trouvée" in status.error
 
     @patch("back_office_lmelp.services.calibre_service.settings")
     def test_service_not_available_when_path_does_not_exist(self, mock_settings):

--- a/tests/test_calibre_settings.py
+++ b/tests/test_calibre_settings.py
@@ -1,0 +1,47 @@
+import os
+from unittest.mock import patch
+
+from back_office_lmelp.settings import Settings
+
+
+class TestCalibreSettings:
+    @patch.dict(os.environ, {}, clear=True)
+    @patch("os.path.isdir")
+    @patch("os.path.isfile")
+    def test_calibre_library_path_detection(self, mock_isfile, mock_isdir):
+        # Case 1: /calibre exists and has metadata.db
+        def isdir_side_effect(path):
+            return path == "/calibre"
+
+        def isfile_side_effect(path):
+            return path == "/calibre/metadata.db"
+
+        mock_isdir.side_effect = isdir_side_effect
+        mock_isfile.side_effect = isfile_side_effect
+
+        settings = Settings()
+        assert settings.calibre_library_path == "/calibre"
+
+        # Case 2: /calibre does not exist
+        mock_isdir.side_effect = None
+        mock_isdir.return_value = False
+
+        settings = Settings()
+        assert settings.calibre_library_path is None
+
+    @patch.dict(os.environ, {}, clear=True)
+    @patch("os.path.isdir")
+    @patch("os.path.isfile")
+    def test_calibre_library_path_no_db(self, mock_isfile, mock_isdir):
+        # Case 3: /calibre exists but NO metadata.db
+        def isdir_side_effect(path):
+            return path == "/calibre"
+
+        def isfile_side_effect(path):
+            return False
+
+        mock_isdir.side_effect = isdir_side_effect
+        mock_isfile.side_effect = isfile_side_effect
+
+        settings = Settings()
+        assert settings.calibre_library_path is None


### PR DESCRIPTION
- Remove CALIBRE_LIBRARY_PATH environment variable support.
- Hardcode Calibre library detection to /calibre directory.
- Update CalibreService to check for /calibre/metadata.db.
- Update documentation (User, Dev, Deployment) to reflect these changes.
- Update docker-compose.yml to remove the environment variable.
- Update tests to match new behavior.
- Add tests/test_calibre_settings.py.

Fixes #122