### PR TITLE
feat(critique): Add critique detail page with note distribution and filters (Issue #191)

### DIFF
--- a/docs/claude/memory/260203-0048-issue191-page-critique-detail.md
+++ b/docs/claude/memory/260203-0048-issue191-page-critique-detail.md
@@ -1,0 +1,73 @@
+# Issue #191 - Page détail critique (/critique/:id)
+
+## Contexte
+
+Création d'une page de détail pour les critiques, accessible depuis les liens déjà cliquables dans le composant AvisTable. La page affiche le profil d'un critique, la distribution de ses notes en barplot CSS, ses coups de coeur, et une liste filtrable de toutes ses oeuvres critiquées.
+
+## Fichiers créés
+
+- `frontend/src/views/CritiqueDetail.vue` : Composant Vue.js suivant le pattern 3 états (loading/error/data) identique à `AuteurDetail.vue` et `LivreDetail.vue`
+- `frontend/tests/integration/CritiqueDetail.test.js` : 11 tests d'intégration (affichage, filtres, états, API)
+- `tests/test_critique_detail.py` : 5 tests backend (endpoint, 404, validation ObjectId, avis vides, flag animateur)
+
+## Fichiers modifiés
+
+- `src/back_office_lmelp/services/mongodb_service.py` : Ajout méthode `get_critique_detail()` (~160 lignes) avec batch-lookup livres/auteurs/émissions
+- `src/back_office_lmelp/app.py` : Ajout endpoint `GET /api/critique/{critique_id}` après les endpoints auteur/livre detail
+- `frontend/src/router/index.js` : Ajout route `/critique/:id` en lazy-loading
+
+## Points techniques importants
+
+### Types MongoDB - Conversions critiques
+
+- `avis.critique_oid` est **String** (pas ObjectId) : la requête utilise directement `critique_id` comme string
+- `avis.livre_oid` est **String** mais `livres._id` est **ObjectId** : conversion explicite avec `ObjectId(livre_oid)` et `contextlib.suppress(Exception)`
+- `avis.emission_oid` est **String** mais `emissions._id` est **ObjectId** : même pattern de conversion
+- `emissions.date` peut être `datetime` ou `str` : vérification avec `isinstance(em_date, datetime)`
+
+### Pattern batch-lookup
+
+La méthode `get_critique_detail()` effectue un seul appel API qui agrège tout :
+1. Trouve le critique dans `critiques_collection`
+2. Récupère tous les avis avec `critique_oid == critique_id`
+3. Batch-lookup des livres, auteurs, émissions en un seul `find({"$in": [...]})`
+4. Calcule distribution des notes (clés "2" à "10"), note_moyenne, coups de coeur (note >= 9)
+5. Retourne le tout en un seul JSON (~200KB max pour le critique le plus prolifique avec 838 avis)
+
+### Barplot CSS-only
+
+Distribution des notes implémentée sans bibliothèque de charts :
+- 9 colonnes (notes 2 à 10) avec hauteur proportionnelle au max
+- Utilise les mêmes classes de couleur que le reste de l'app (`note-excellent`, `note-good`, `note-average`, `note-poor`)
+- Compteur affiché au-dessus de chaque barre
+
+### Filtrage côté client
+
+3 filtres combinables sur les oeuvres :
+- Recherche texte avec `removeAccents` de `@/utils/textUtils` (insensible aux accents)
+- Plage de notes : Excellent (9-10), Bon (7-8), Moyen (5-6), Faible (<5)
+- Section : Programme, Coup de coeur
+
+### Liens de navigation
+
+Depuis la page critique :
+- Titre du livre -> `/livre/{livre_oid}`
+- Nom de l'auteur -> `/auteur/{auteur_oid}`
+- Date d'émission -> `/emissions/{YYYYMMDD}`
+
+## Pattern réutilisable
+
+La page suit exactement le même pattern que `AuteurDetail.vue` et `LivreDetail.vue` :
+- Navigation component en haut
+- 3 états : loading spinner, error avec bouton retour, contenu
+- Appel API relatif (`/api/critique/${id}`) pour bénéficier du proxy Vite
+- Gestion erreur 404 spécifique
+- Memory guard côté backend
+- Validation ObjectId (24 caractères hex)
+
+## Volumes de données
+
+- 28 critiques dans la collection `critiques`
+- 4055 avis au total dans la collection `avis`
+- Max 838 avis par critique (filtrage côté client approprié)
+- Distribution des notes entre 2 et 10

--- a/docs/dev/api.md
+++ b/docs/dev/api.md
@@ -977,6 +977,74 @@ Récupère les détails d'un livre avec tous les épisodes où il est mentionné
 }
 ```
 
+### GET /api/critique/{critique_id}
+
+Récupère les détails d'un critique avec statistiques, distribution des notes, coups de cœur et liste des œuvres critiquées.
+
+#### Paramètres
+
+- `critique_id` (path, required): ObjectId MongoDB du critique (24 caractères hexadécimaux)
+
+#### Réponse
+
+**200 OK**
+```json
+{
+  "critique_id": "694eb58bffd25d11ce052759",  // pragma: allowlist secret
+  "nom": "Arnaud Viviant",
+  "animateur": false,
+  "variantes": ["Arnaud Vivian"],
+  "nombre_avis": 838,
+  "note_moyenne": 6.8,
+  "note_distribution": {
+    "2": 31, "3": 72, "4": 72, "5": 66,
+    "6": 75, "7": 80, "8": 188, "9": 223, "10": 31
+  },
+  "coups_de_coeur": [
+    {
+      "livre_oid": "6948458b4c7793c317f9f795",  // pragma: allowlist secret
+      "livre_titre": "Combats de filles",
+      "auteur_nom": "Rita Bullwinkel",
+      "auteur_oid": "694845004c7793c317f9f700",  // pragma: allowlist secret
+      "editeur": "La Croisée",
+      "note": 9,
+      "commentaire": "Très belle découverte",
+      "section": "programme",
+      "emission_date": "2026-01-18",
+      "emission_oid": "694fea91e46eedc769bcd996"  // pragma: allowlist secret
+    }
+  ],
+  "oeuvres": [
+    {
+      "livre_oid": "6948458b4c7793c317f9f795",  // pragma: allowlist secret
+      "livre_titre": "Combats de filles",
+      "auteur_nom": "Rita Bullwinkel",
+      "auteur_oid": "694845004c7793c317f9f700",  // pragma: allowlist secret
+      "editeur": "La Croisée",
+      "note": 9,
+      "commentaire": "Très belle découverte",
+      "section": "programme",
+      "emission_date": "2026-01-18",
+      "emission_oid": "694fea91e46eedc769bcd996"  // pragma: allowlist secret
+    }
+  ]
+}
+```
+
+**Notes**:
+- Les coups de cœur sont les avis avec une note >= 9
+- La distribution des notes utilise des clés string de "2" à "10"
+- Les œuvres sont triées par date d'émission décroissante
+- Batch-lookup des livres, auteurs et émissions pour enrichir chaque avis
+- Types MongoDB : `critique_oid` dans `avis` est String, `critiques._id` est ObjectId
+
+**404 Not Found** - Critique non trouvé
+```json
+{
+  "detail": "Critique non trouvé"
+}
+```
+
 ---
 
 ## Search API

--- a/docs/user/detail-pages.md
+++ b/docs/user/detail-pages.md
@@ -1,6 +1,6 @@
-# Pages de Détail Auteur et Livre
+# Pages de Détail Auteur, Livre et Critique
 
-Les pages de détail permettent de consulter toutes les informations relatives à un auteur ou à un livre, avec navigation directe vers les contenus associés.
+Les pages de détail permettent de consulter toutes les informations relatives à un auteur, un livre ou un critique, avec navigation directe vers les contenus associés.
 
 ## Accès aux pages de détail
 
@@ -10,6 +10,12 @@ Les résultats de recherche (simple ou avancée) proposent des liens clickables 
 
 - **Auteur** : Cliquez sur le nom d'un auteur pour accéder à sa page détail
 - **Livre** : Cliquez sur le titre d'un livre pour accéder à sa page détail
+
+### Depuis les émissions
+
+Dans les tableaux d'avis des émissions, les noms de critiques sont clickables :
+
+- **Critique** : Cliquez sur le nom d'un critique pour accéder à sa page détail
 
 ### Depuis la validation bibliographique
 
@@ -22,6 +28,7 @@ Dans la page **Livres et Auteurs** (`/livres-auteurs`), les auteurs et titres va
 
 - **Page auteur** : `http://localhost:5173/auteur/{id}`
 - **Page livre** : `http://localhost:5173/livre/{id}`
+- **Page critique** : `http://localhost:5173/critique/{id}`
 
 ## Page Détail Auteur
 
@@ -116,6 +123,88 @@ Dans la page **Livres et Auteurs** (`/livres-auteurs`), les auteurs et titres va
 - **Cliquer sur un épisode** : Navigation vers la validation bibliographique avec l'épisode pré-sélectionné
 - **Retour au Dashboard** : Bouton "🏠 Accueil" en haut de page
 
+## Page Détail Critique
+
+### Vue d'ensemble
+
+```
+┌─────────────────────────────────────────────────────────────┐
+│ 🏠 Accueil                                                   │
+└─────────────────────────────────────────────────────────────┘
+
+┌─────────────────────────────────────────────────────────────┐
+│  🎙️  Arnaud Viviant                                          │
+│      📊 838 avis    ⭐ 6.8                                    │
+│      Variantes : Arnaud Vivian                                │
+└─────────────────────────────────────────────────────────────┘
+
+┌─────────────────────────────────────────────────────────────┐
+│  Distribution des notes                                       │
+│  ▓  ▓▓ ▓▓ ▓  ▓  ▓▓ ████ ████████ ▓                          │
+│  2  3  4  5  6  7  8    9        10                          │
+│  Note moyenne : 6.8 · 838 avis au total                       │
+└─────────────────────────────────────────────────────────────┘
+
+┌─────────────────────────────────────────────────────────────┐
+│  Coups de cœur (223)                                          │
+│  📖 Combats de filles - Rita Bullwinkel  ⭐ 9                 │
+│      Très belle découverte, original                          │
+│      📅 18 janvier 2026                                       │
+└─────────────────────────────────────────────────────────────┘
+
+┌─────────────────────────────────────────────────────────────┐
+│  Œuvres critiquées (838/838)                                  │
+│  🔍 [Rechercher...] [Notes ▾] [Section ▾]                   │
+│                                                               │
+│  📖 Combats de filles - Rita Bullwinkel  ⭐ 9                │
+│      La Croisée · programme                                   │
+│      📅 18 janvier 2026                                       │
+└─────────────────────────────────────────────────────────────┘
+```
+
+### Informations affichées
+
+- **Nom du critique** : Affiché en haut de page
+- **Badge animateur** : Si le critique est aussi animateur de l'émission
+- **Nombre d'avis** : Total des avis donnés par ce critique
+- **Note moyenne** : Moyenne de toutes les notes, avec code couleur
+- **Variantes** : Autres orthographes connues du nom
+
+### Distribution des notes
+
+Un graphique en barres CSS affiche la distribution des notes de 2 à 10 :
+
+- Chaque barre est proportionnelle au nombre d'avis avec cette note
+- Les couleurs suivent le code habituel (vert >= 9, jaune-vert >= 7, jaune >= 5, rouge < 5)
+- Le compteur exact est affiché au-dessus de chaque barre
+
+### Coups de cœur
+
+Liste des œuvres ayant reçu une note de 9 ou 10 :
+
+- Titre du livre (clickable vers la page livre)
+- Auteur (clickable vers la page auteur)
+- Note et commentaire
+- Date d'émission (clickable vers la page émission)
+
+### Œuvres critiquées avec filtres
+
+La liste complète des œuvres dispose de trois filtres combinables :
+
+- **Recherche textuelle** : Filtre par titre de livre ou nom d'auteur (insensible aux accents)
+- **Plage de notes** : Excellent (9-10), Bon (7-8), Moyen (5-6), Faible (< 5)
+- **Section** : Programme ou Coup de cœur
+
+Le compteur affiché (ex: "320/838") indique le nombre de résultats filtrés par rapport au total.
+
+### Actions disponibles
+
+- **Cliquer sur un titre** : Accès à la page détail du livre
+- **Cliquer sur un auteur** : Accès à la page détail de l'auteur
+- **Cliquer sur une date** : Accès à la page émission correspondante
+- **Filtrer les œuvres** : Recherche texte, notes, ou section
+- **Retour** : Bouton "← Retour" en bas de page
+
 ## Liens directs vers validation bibliographique
 
 ### Depuis la page livre
@@ -198,6 +287,10 @@ graph LR
     C -->|Clic épisode| D[Validation Biblio]
     D -->|Clic auteur| B
     D -->|Clic titre| C
+    E[Émission] -->|Clic critique| F[Page Critique]
+    F -->|Clic livre| C
+    F -->|Clic auteur| B
+    F -->|Clic émission| E
 ```
 
 ### Exemple de parcours utilisateur

--- a/frontend/src/router/index.js
+++ b/frontend/src/router/index.js
@@ -83,6 +83,14 @@ const routes = [
     }
   },
   {
+    path: '/critique/:id',
+    name: 'CritiqueDetail',
+    component: () => import('../views/CritiqueDetail.vue'),
+    meta: {
+      title: 'Détail Critique - Back-office LMELP'
+    }
+  },
+  {
     path: '/masquer-episodes',
     name: 'MasquerEpisodes',
     component: MasquerEpisodes,

--- a/frontend/src/views/CritiqueDetail.vue
+++ b/frontend/src/views/CritiqueDetail.vue
@@ -1,0 +1,816 @@
+<template>
+  <div class="critique-detail-page">
+    <!-- Navigation -->
+    <Navigation pageTitle="Détail du critique" />
+
+    <!-- État de chargement -->
+    <div v-if="loading" class="loading-state" data-test="loading">
+      <div class="loading-spinner"></div>
+      <span>Chargement des informations du critique...</span>
+    </div>
+
+    <!-- Message d'erreur -->
+    <div v-else-if="error" class="error-state" data-test="error">
+      <div class="error-icon">⚠️</div>
+      <span>{{ error }}</span>
+      <button @click="$router.back()" class="btn-secondary">
+        Retour
+      </button>
+    </div>
+
+    <!-- Contenu du critique -->
+    <div v-else-if="critique" class="critique-content">
+      <!-- En-tête critique -->
+      <div class="critique-header">
+        <div class="critique-header-container">
+          <div class="critique-icon">🎙️</div>
+          <div class="critique-info">
+            <h1 class="critique-name">
+              {{ critique.nom }}
+              <span v-if="critique.animateur" class="animateur-badge" data-test="animateur-badge">
+                Animateur
+              </span>
+            </h1>
+            <div class="critique-stats">
+              <span class="stat-badge">
+                {{ critique.nombre_avis }} avis
+              </span>
+              <span
+                v-if="critique.note_moyenne != null"
+                class="note-badge"
+                :class="noteClass(critique.note_moyenne)"
+                data-test="note-moyenne"
+              >
+                {{ critique.note_moyenne.toFixed(1) }}
+              </span>
+            </div>
+            <div v-if="critique.variantes && critique.variantes.length > 0" class="variantes">
+              <span class="variantes-label">Variantes :</span>
+              {{ critique.variantes.join(', ') }}
+            </div>
+          </div>
+        </div>
+      </div>
+
+      <!-- Distribution des notes -->
+      <section v-if="critique.nombre_avis > 0" class="distribution-section">
+        <h2>Distribution des notes</h2>
+        <div class="distribution-chart">
+          <div
+            v-for="note in noteLabels"
+            :key="note"
+            class="distribution-column"
+            data-test="distribution-bar"
+          >
+            <div class="bar-container">
+              <div
+                class="bar"
+                :class="noteClass(parseInt(note))"
+                :style="{ height: barHeight(critique.note_distribution[note]) + '%' }"
+              >
+                <span v-if="critique.note_distribution[note] > 0" class="bar-count">
+                  {{ critique.note_distribution[note] }}
+                </span>
+              </div>
+            </div>
+            <div class="bar-label">{{ note }}</div>
+          </div>
+        </div>
+        <div class="distribution-legend">
+          <span>
+            Note moyenne :
+            <strong
+              v-if="critique.note_moyenne != null"
+              :class="noteClass(critique.note_moyenne)"
+            >
+              {{ critique.note_moyenne.toFixed(1) }}
+            </strong>
+            <strong v-else>-</strong>
+          </span>
+          <span>{{ critique.nombre_avis }} avis au total</span>
+        </div>
+      </section>
+
+      <!-- Coups de coeur -->
+      <section v-if="critique.coups_de_coeur.length > 0" class="coups-de-coeur-section">
+        <h2>
+          Coups de cœur
+          <span class="section-count">{{ critique.coups_de_coeur.length }}</span>
+        </h2>
+        <div class="coups-de-coeur-list">
+          <div
+            v-for="(coup, index) in critique.coups_de_coeur"
+            :key="index"
+            class="coup-de-coeur-card"
+            data-test="coup-de-coeur-item"
+          >
+            <div class="coup-info">
+              <div class="coup-title-row">
+                <router-link
+                  v-if="coup.livre_oid"
+                  :to="`/livre/${coup.livre_oid}`"
+                  class="livre-link"
+                >
+                  {{ coup.livre_titre }}
+                </router-link>
+                <span v-else>{{ coup.livre_titre }}</span>
+                <span class="note-badge" :class="noteClass(coup.note)">
+                  {{ coup.note }}
+                </span>
+              </div>
+              <div class="coup-meta">
+                <router-link
+                  v-if="coup.auteur_oid"
+                  :to="`/auteur/${coup.auteur_oid}`"
+                  class="auteur-link"
+                >
+                  {{ coup.auteur_nom }}
+                </router-link>
+                <span v-else class="auteur-name">{{ coup.auteur_nom }}</span>
+                <span v-if="coup.editeur" class="editeur">· {{ coup.editeur }}</span>
+              </div>
+              <p v-if="coup.commentaire" class="commentaire">{{ coup.commentaire }}</p>
+              <router-link
+                v-if="coup.emission_date"
+                :to="`/emissions/${formatDateForUrl(coup.emission_date)}`"
+                class="emission-date-chip"
+              >
+                {{ formatDate(coup.emission_date) }}
+              </router-link>
+            </div>
+          </div>
+        </div>
+      </section>
+
+      <!-- Liste des oeuvres avec filtres -->
+      <section class="oeuvres-section">
+        <h2>
+          Œuvres critiquées
+          <span class="section-count">{{ filteredOeuvres.length }}/{{ critique.oeuvres.length }}</span>
+        </h2>
+
+        <!-- Filtres -->
+        <div v-if="critique.oeuvres.length > 0" class="filters">
+          <input
+            v-model="searchFilter"
+            type="text"
+            placeholder="Rechercher un titre ou un auteur..."
+            class="filter-input"
+            data-test="search-filter"
+          />
+          <select v-model="noteFilter" class="filter-select" data-test="note-filter">
+            <option value="all">Toutes les notes</option>
+            <option value="excellent">9-10 (Excellent)</option>
+            <option value="good">7-8 (Bon)</option>
+            <option value="average">5-6 (Moyen)</option>
+            <option value="poor">&lt; 5 (Faible)</option>
+          </select>
+          <select v-model="sectionFilter" class="filter-select" data-test="section-filter">
+            <option value="all">Toutes les sections</option>
+            <option value="programme">Programme</option>
+            <option value="coup_de_coeur">Coup de cœur</option>
+          </select>
+        </div>
+
+        <!-- Message si aucune oeuvre -->
+        <div v-if="critique.oeuvres.length === 0" class="empty-state">
+          <p>Aucun avis trouvé pour ce critique</p>
+        </div>
+
+        <!-- Message si filtres vident la liste -->
+        <div v-else-if="filteredOeuvres.length === 0" class="empty-state">
+          <p>Aucun résultat pour ces critères de recherche</p>
+        </div>
+
+        <!-- Liste des oeuvres -->
+        <div v-else class="oeuvres-list">
+          <div
+            v-for="(oeuvre, index) in filteredOeuvres"
+            :key="index"
+            class="oeuvre-card"
+            data-test="oeuvre-item"
+          >
+            <div class="oeuvre-info">
+              <div class="oeuvre-title-row">
+                <router-link
+                  v-if="oeuvre.livre_oid"
+                  :to="`/livre/${oeuvre.livre_oid}`"
+                  class="livre-link"
+                >
+                  {{ oeuvre.livre_titre }}
+                </router-link>
+                <span v-else>{{ oeuvre.livre_titre }}</span>
+                <span
+                  v-if="oeuvre.note != null"
+                  class="note-badge"
+                  :class="noteClass(oeuvre.note)"
+                >
+                  {{ oeuvre.note }}
+                </span>
+              </div>
+              <div class="oeuvre-meta">
+                <router-link
+                  v-if="oeuvre.auteur_oid"
+                  :to="`/auteur/${oeuvre.auteur_oid}`"
+                  class="auteur-link"
+                >
+                  {{ oeuvre.auteur_nom }}
+                </router-link>
+                <span v-else class="auteur-name">{{ oeuvre.auteur_nom }}</span>
+                <span v-if="oeuvre.editeur" class="editeur">· {{ oeuvre.editeur }}</span>
+                <span v-if="oeuvre.section" class="section-badge">{{ oeuvre.section }}</span>
+              </div>
+              <p v-if="oeuvre.commentaire" class="commentaire">{{ oeuvre.commentaire }}</p>
+              <router-link
+                v-if="oeuvre.emission_date"
+                :to="`/emissions/${formatDateForUrl(oeuvre.emission_date)}`"
+                class="emission-date-chip"
+              >
+                {{ formatDate(oeuvre.emission_date) }}
+              </router-link>
+            </div>
+          </div>
+        </div>
+      </section>
+
+      <!-- Bouton retour -->
+      <div class="actions">
+        <button @click="$router.back()" class="btn-secondary">
+          ← Retour
+        </button>
+      </div>
+    </div>
+  </div>
+</template>
+
+<script>
+import axios from 'axios';
+import Navigation from '../components/Navigation.vue';
+import { removeAccents } from '@/utils/textUtils';
+
+export default {
+  name: 'CritiqueDetail',
+  components: {
+    Navigation
+  },
+  data() {
+    return {
+      critique: null,
+      loading: false,
+      error: null,
+      searchFilter: '',
+      noteFilter: 'all',
+      sectionFilter: 'all',
+      noteLabels: ['2', '3', '4', '5', '6', '7', '8', '9', '10']
+    };
+  },
+  computed: {
+    filteredOeuvres() {
+      if (!this.critique) return [];
+      let oeuvres = [...this.critique.oeuvres];
+
+      // Filtre texte (insensible aux accents)
+      if (this.searchFilter.trim()) {
+        const search = removeAccents(this.searchFilter.toLowerCase());
+        oeuvres = oeuvres.filter(o =>
+          removeAccents((o.livre_titre || '').toLowerCase()).includes(search) ||
+          removeAccents((o.auteur_nom || '').toLowerCase()).includes(search)
+        );
+      }
+
+      // Filtre par plage de notes
+      if (this.noteFilter !== 'all') {
+        oeuvres = oeuvres.filter(o => {
+          if (o.note == null) return false;
+          switch (this.noteFilter) {
+            case 'excellent': return o.note >= 9;
+            case 'good': return o.note >= 7 && o.note < 9;
+            case 'average': return o.note >= 5 && o.note < 7;
+            case 'poor': return o.note < 5;
+            default: return true;
+          }
+        });
+      }
+
+      // Filtre par section
+      if (this.sectionFilter !== 'all') {
+        oeuvres = oeuvres.filter(o => o.section === this.sectionFilter);
+      }
+
+      return oeuvres;
+    },
+    maxDistributionCount() {
+      if (!this.critique?.note_distribution) return 1;
+      return Math.max(...Object.values(this.critique.note_distribution), 1);
+    }
+  },
+  async mounted() {
+    await this.loadCritique();
+  },
+  methods: {
+    async loadCritique() {
+      this.loading = true;
+      this.error = null;
+
+      try {
+        const critiqueId = this.$route.params.id;
+        const response = await axios.get(`/api/critique/${critiqueId}`);
+        this.critique = response.data;
+      } catch (err) {
+        console.error('Erreur lors du chargement du critique:', err);
+        if (err.response?.status === 404) {
+          this.error = 'Critique non trouvé';
+        } else if (err.response?.data?.detail) {
+          this.error = err.response.data.detail;
+        } else {
+          this.error = 'Une erreur est survenue lors du chargement du critique';
+        }
+      } finally {
+        this.loading = false;
+      }
+    },
+    noteClass(note) {
+      if (note >= 9) return 'note-excellent';
+      if (note >= 7) return 'note-good';
+      if (note >= 5) return 'note-average';
+      return 'note-poor';
+    },
+    barHeight(count) {
+      return Math.round((count / this.maxDistributionCount) * 100);
+    },
+    formatDate(dateString) {
+      if (!dateString) return '';
+      const date = new Date(dateString);
+      const options = { year: 'numeric', month: 'long', day: 'numeric' };
+      return date.toLocaleDateString('fr-FR', options);
+    },
+    formatDateForUrl(dateString) {
+      if (!dateString) return '';
+      return dateString.replace(/-/g, '');
+    }
+  }
+};
+</script>
+
+<style scoped>
+.critique-detail-page {
+  min-height: 100vh;
+  background-color: #f5f5f5;
+}
+
+/* États loading et error */
+.loading-state,
+.error-state {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  min-height: 400px;
+  gap: 1rem;
+  padding: 2rem;
+}
+
+.loading-spinner {
+  width: 40px;
+  height: 40px;
+  border: 4px solid #f3f3f3;
+  border-top: 4px solid #2c3e50;
+  border-radius: 50%;
+  animation: spin 1s linear infinite;
+}
+
+@keyframes spin {
+  0% { transform: rotate(0deg); }
+  100% { transform: rotate(360deg); }
+}
+
+.error-icon {
+  font-size: 3rem;
+}
+
+.error-state span {
+  color: #d32f2f;
+  font-size: 1.1rem;
+}
+
+/* Contenu critique */
+.critique-content {
+  max-width: 1200px;
+  margin: 0 auto;
+  padding: 2rem;
+}
+
+/* En-tête */
+.critique-header {
+  background: white;
+  border-radius: 8px;
+  padding: 2rem;
+  margin-bottom: 2rem;
+  box-shadow: 0 2px 4px rgba(0, 0, 0, 0.1);
+}
+
+.critique-header-container {
+  display: flex;
+  gap: 1.5rem;
+  align-items: center;
+}
+
+.critique-icon {
+  font-size: 3rem;
+  flex-shrink: 0;
+}
+
+.critique-info {
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+}
+
+.critique-name {
+  font-size: 2rem;
+  color: #2c3e50;
+  margin: 0;
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+}
+
+.animateur-badge {
+  background: #ff9800;
+  color: white;
+  padding: 0.25rem 0.75rem;
+  border-radius: 12px;
+  font-size: 0.8rem;
+  font-weight: 600;
+}
+
+.critique-stats {
+  display: flex;
+  gap: 1rem;
+  align-items: center;
+}
+
+.stat-badge {
+  background: #e3f2fd;
+  color: #1976d2;
+  padding: 0.5rem 1rem;
+  border-radius: 20px;
+  font-weight: 500;
+  font-size: 0.9rem;
+}
+
+.variantes {
+  color: #757575;
+  font-size: 0.9rem;
+}
+
+.variantes-label {
+  font-weight: 600;
+}
+
+/* Note badges */
+.note-badge {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  min-width: 36px;
+  height: 28px;
+  padding: 0 0.4rem;
+  border-radius: 14px;
+  color: white;
+  font-weight: 700;
+  font-size: 0.85rem;
+  flex-shrink: 0;
+}
+
+.note-excellent {
+  background: #00C851;
+}
+
+.note-good {
+  background: #8BC34A;
+}
+
+.note-average {
+  background: #CDDC39;
+  color: #333;
+}
+
+.note-poor {
+  background: #F44336;
+}
+
+/* Distribution des notes */
+.distribution-section {
+  background: white;
+  border-radius: 8px;
+  padding: 2rem;
+  margin-bottom: 2rem;
+  box-shadow: 0 2px 4px rgba(0, 0, 0, 0.1);
+}
+
+.distribution-section h2 {
+  font-size: 1.5rem;
+  color: #2c3e50;
+  margin: 0 0 1.5rem 0;
+}
+
+.distribution-chart {
+  display: flex;
+  align-items: flex-end;
+  gap: 0.5rem;
+  height: 220px;
+  padding: 1rem 0;
+  border-bottom: 2px solid #e0e0e0;
+}
+
+.distribution-column {
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+}
+
+.bar-container {
+  width: 100%;
+  height: 180px;
+  display: flex;
+  align-items: flex-end;
+  justify-content: center;
+}
+
+.bar {
+  width: 80%;
+  max-width: 60px;
+  border-radius: 4px 4px 0 0;
+  transition: height 0.3s ease;
+  position: relative;
+  min-height: 2px;
+}
+
+.bar-count {
+  position: absolute;
+  top: -20px;
+  left: 50%;
+  transform: translateX(-50%);
+  font-size: 0.75rem;
+  font-weight: 600;
+  color: #333;
+}
+
+.bar-label {
+  margin-top: 0.5rem;
+  font-weight: 600;
+  color: #555;
+}
+
+.distribution-legend {
+  display: flex;
+  justify-content: space-between;
+  padding-top: 1rem;
+  color: #757575;
+  font-size: 0.9rem;
+}
+
+/* Coups de coeur */
+.coups-de-coeur-section {
+  background: white;
+  border-radius: 8px;
+  padding: 2rem;
+  margin-bottom: 2rem;
+  box-shadow: 0 2px 4px rgba(0, 0, 0, 0.1);
+}
+
+.coups-de-coeur-section h2 {
+  font-size: 1.5rem;
+  color: #2c3e50;
+  margin: 0 0 1.5rem 0;
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+}
+
+.section-count {
+  background: #e3f2fd;
+  color: #1976d2;
+  padding: 0.2rem 0.6rem;
+  border-radius: 12px;
+  font-size: 0.85rem;
+  font-weight: 500;
+}
+
+.coups-de-coeur-list {
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+}
+
+.coup-de-coeur-card {
+  padding: 1rem;
+  border: 1px solid #c8e6c9;
+  border-left: 4px solid #00C851;
+  border-radius: 6px;
+  background: #f1f8e9;
+  transition: all 0.2s ease;
+}
+
+.coup-de-coeur-card:hover {
+  border-color: #00C851;
+  box-shadow: 0 2px 8px rgba(0, 200, 81, 0.15);
+}
+
+/* Oeuvres section */
+.oeuvres-section {
+  background: white;
+  border-radius: 8px;
+  padding: 2rem;
+  margin-bottom: 2rem;
+  box-shadow: 0 2px 4px rgba(0, 0, 0, 0.1);
+}
+
+.oeuvres-section h2 {
+  font-size: 1.5rem;
+  color: #2c3e50;
+  margin: 0 0 1.5rem 0;
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+}
+
+/* Filtres */
+.filters {
+  display: flex;
+  gap: 1rem;
+  margin-bottom: 1.5rem;
+  flex-wrap: wrap;
+}
+
+.filter-input {
+  flex: 1;
+  min-width: 200px;
+  padding: 0.6rem 1rem;
+  border: 1px solid #e0e0e0;
+  border-radius: 6px;
+  font-size: 0.9rem;
+  transition: border-color 0.2s ease;
+}
+
+.filter-input:focus {
+  outline: none;
+  border-color: #1976d2;
+  box-shadow: 0 0 0 2px rgba(25, 118, 210, 0.1);
+}
+
+.filter-select {
+  padding: 0.6rem 1rem;
+  border: 1px solid #e0e0e0;
+  border-radius: 6px;
+  font-size: 0.9rem;
+  background: white;
+  cursor: pointer;
+}
+
+.filter-select:focus {
+  outline: none;
+  border-color: #1976d2;
+}
+
+/* Empty state */
+.empty-state {
+  text-align: center;
+  padding: 3rem;
+  color: #757575;
+}
+
+/* Liste des oeuvres */
+.oeuvres-list {
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+}
+
+.oeuvre-card {
+  padding: 1rem;
+  border: 1px solid #e0e0e0;
+  border-radius: 6px;
+  background: #fafafa;
+  transition: all 0.2s ease;
+}
+
+.oeuvre-card:hover {
+  background: #f5f5f5;
+  border-color: #1976d2;
+  transform: translateX(4px);
+}
+
+.oeuvre-info,
+.coup-info {
+  display: flex;
+  flex-direction: column;
+  gap: 0.4rem;
+}
+
+.oeuvre-title-row,
+.coup-title-row {
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+}
+
+.livre-link {
+  text-decoration: none;
+  color: #2c3e50;
+  font-weight: 600;
+  font-size: 1.05rem;
+  transition: color 0.2s ease;
+}
+
+.livre-link:hover {
+  color: #1976d2;
+}
+
+.oeuvre-meta,
+.coup-meta {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  color: #757575;
+  font-size: 0.9rem;
+}
+
+.auteur-link {
+  text-decoration: none;
+  color: #1976d2;
+  transition: color 0.2s ease;
+}
+
+.auteur-link:hover {
+  color: #1565c0;
+  text-decoration: underline;
+}
+
+.auteur-name {
+  color: #555;
+}
+
+.editeur {
+  color: #9e9e9e;
+}
+
+.section-badge {
+  background: #f3e5f5;
+  color: #7b1fa2;
+  padding: 0.15rem 0.5rem;
+  border-radius: 10px;
+  font-size: 0.75rem;
+  font-weight: 500;
+}
+
+.commentaire {
+  color: #555;
+  font-size: 0.9rem;
+  font-style: italic;
+  margin: 0.25rem 0;
+  line-height: 1.4;
+}
+
+/* Emission date chips */
+.emission-date-chip {
+  display: inline-block;
+  padding: 0.2rem 0.6rem;
+  background: #e3f2fd;
+  color: #1976d2;
+  border-radius: 12px;
+  font-size: 0.8rem;
+  text-decoration: none;
+  transition: background 0.2s ease;
+  align-self: flex-start;
+}
+
+.emission-date-chip:hover {
+  background: #bbdefb;
+}
+
+/* Actions */
+.actions {
+  display: flex;
+  gap: 1rem;
+  padding: 1rem 0;
+}
+
+.btn-secondary {
+  padding: 0.75rem 1.5rem;
+  background: #e0e0e0;
+  border: none;
+  border-radius: 6px;
+  color: #2c3e50;
+  font-size: 1rem;
+  cursor: pointer;
+  transition: all 0.2s ease;
+}
+
+.btn-secondary:hover {
+  background: #bdbdbd;
+}
+</style>

--- a/frontend/tests/integration/CritiqueDetail.test.js
+++ b/frontend/tests/integration/CritiqueDetail.test.js
@@ -1,0 +1,315 @@
+/**
+ * Tests d'intégration pour la page de détail d'un critique (Issue #191)
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { mount, flushPromises } from '@vue/test-utils';
+import { createRouter, createWebHistory } from 'vue-router';
+import CritiqueDetail from '../../src/views/CritiqueDetail.vue';
+import axios from 'axios';
+
+// Mock axios
+vi.mock('axios');
+
+describe('CritiqueDetail - Tests d\'intégration', () => {
+  let wrapper;
+  let router;
+
+  const mockCritiqueData = {
+    critique_id: '694eb58bffd25d11ce052759', // pragma: allowlist secret
+    nom: 'Arnaud Viviant',
+    animateur: false,
+    variantes: ['Arnaud Vivian'],
+    nombre_avis: 3,
+    note_moyenne: 7.3,
+    note_distribution: {
+      '2': 0, '3': 0, '4': 0, '5': 0,
+      '6': 1, '7': 0, '8': 1, '9': 1, '10': 0
+    },
+    coups_de_coeur: [
+      {
+        livre_oid: '6948458b4c7793c317f9f795', // pragma: allowlist secret
+        livre_titre: 'Combats de filles',
+        auteur_nom: 'Rita Bullwinkel',
+        auteur_oid: '694845004c7793c317f9f700', // pragma: allowlist secret
+        editeur: 'La Croisée',
+        note: 9,
+        commentaire: 'Très belle découverte, original',
+        section: 'programme',
+        emission_date: '2026-01-18',
+        emission_oid: '694fea91e46eedc769bcd996' // pragma: allowlist secret
+      }
+    ],
+    oeuvres: [
+      {
+        livre_oid: '6948458b4c7793c317f9f795', // pragma: allowlist secret
+        livre_titre: 'Combats de filles',
+        auteur_nom: 'Rita Bullwinkel',
+        auteur_oid: '694845004c7793c317f9f700', // pragma: allowlist secret
+        editeur: 'La Croisée',
+        note: 9,
+        commentaire: 'Très belle découverte, original',
+        section: 'programme',
+        emission_date: '2026-01-18',
+        emission_oid: '694fea91e46eedc769bcd996' // pragma: allowlist secret
+      },
+      {
+        livre_oid: '6948458b4c7793c317f9f796', // pragma: allowlist secret
+        livre_titre: 'Le Grand Vertige',
+        auteur_nom: 'Pierre Ducrozet',
+        auteur_oid: '694845004c7793c317f9f701', // pragma: allowlist secret
+        editeur: 'Actes Sud',
+        note: 8,
+        commentaire: 'Roman ambitieux et maîtrisé',
+        section: 'programme',
+        emission_date: '2025-12-14',
+        emission_oid: '694fea91e46eedc769bcd997' // pragma: allowlist secret
+      },
+      {
+        livre_oid: '6948458b4c7793c317f9f797', // pragma: allowlist secret
+        livre_titre: 'La Vie nouvelle',
+        auteur_nom: 'Tom Crewe',
+        auteur_oid: '694845004c7793c317f9f702', // pragma: allowlist secret
+        editeur: 'Gallimard',
+        note: 6,
+        commentaire: 'Intéressant mais inégal',
+        section: 'programme',
+        emission_date: '2025-11-09',
+        emission_oid: '694fea91e46eedc769bcd998' // pragma: allowlist secret
+      }
+    ]
+  };
+
+  beforeEach(async () => {
+    vi.clearAllMocks();
+
+    router = createRouter({
+      history: createWebHistory(),
+      routes: [
+        {
+          path: '/critique/:id',
+          name: 'CritiqueDetail',
+          component: CritiqueDetail
+        },
+        {
+          path: '/livre/:id',
+          name: 'LivreDetail',
+          component: { template: '<div>Livre Detail</div>' }
+        },
+        {
+          path: '/auteur/:id',
+          name: 'AuteurDetail',
+          component: { template: '<div>Auteur Detail</div>' }
+        },
+        {
+          path: '/emissions/:date',
+          name: 'EmissionDetail',
+          component: { template: '<div>Emission Detail</div>' }
+        }
+      ]
+    });
+
+    await router.push('/critique/694eb58bffd25d11ce052759'); // pragma: allowlist secret
+    await router.isReady();
+  });
+
+  it('should display critique name and avis count', async () => {
+    // GIVEN: L'API retourne les données d'un critique
+    axios.get.mockResolvedValueOnce({ data: mockCritiqueData });
+
+    // WHEN: Le composant est monté
+    wrapper = mount(CritiqueDetail, {
+      global: { plugins: [router] }
+    });
+    await flushPromises();
+
+    // THEN: Le nom et le nombre d'avis sont affichés
+    expect(wrapper.text()).toContain('Arnaud Viviant');
+    expect(wrapper.text()).toContain('3');
+  });
+
+  it('should display note moyenne with correct color class', async () => {
+    // GIVEN: L'API retourne un critique avec note_moyenne 7.3
+    axios.get.mockResolvedValueOnce({ data: mockCritiqueData });
+
+    // WHEN: Le composant est monté
+    wrapper = mount(CritiqueDetail, {
+      global: { plugins: [router] }
+    });
+    await flushPromises();
+
+    // THEN: La note moyenne est affichée avec la bonne classe
+    expect(wrapper.text()).toContain('7.3');
+    const noteBadge = wrapper.find('[data-test="note-moyenne"]');
+    expect(noteBadge.exists()).toBe(true);
+    expect(noteBadge.classes()).toContain('note-good');
+  });
+
+  it('should display loading state while fetching data', async () => {
+    // GIVEN: L'API met du temps à répondre
+    let resolvePromise;
+    axios.get.mockImplementation(() => new Promise((resolve) => {
+      resolvePromise = resolve;
+    }));
+
+    // WHEN: Le composant est monté
+    wrapper = mount(CritiqueDetail, {
+      global: { plugins: [router] }
+    });
+    await wrapper.vm.$nextTick();
+
+    // THEN: Un indicateur de chargement est affiché
+    expect(wrapper.find('[data-test="loading"]').exists()).toBe(true);
+
+    // Cleanup
+    if (resolvePromise) {
+      resolvePromise({ data: mockCritiqueData });
+    }
+    await flushPromises();
+  });
+
+  it('should display error message when critique not found', async () => {
+    // GIVEN: L'API retourne une erreur 404
+    axios.get.mockRejectedValueOnce({
+      response: {
+        status: 404,
+        data: { detail: 'Critique non trouvé' }
+      }
+    });
+
+    // WHEN: Le composant est monté
+    wrapper = mount(CritiqueDetail, {
+      global: { plugins: [router] }
+    });
+    await flushPromises();
+
+    // THEN: Un message d'erreur est affiché
+    expect(wrapper.find('[data-test="error"]').exists()).toBe(true);
+    expect(wrapper.text()).toContain('Critique non trouvé');
+  });
+
+  it('should render note distribution bars', async () => {
+    // GIVEN: L'API retourne un critique avec distribution des notes
+    axios.get.mockResolvedValueOnce({ data: mockCritiqueData });
+
+    // WHEN: Le composant est monté
+    wrapper = mount(CritiqueDetail, {
+      global: { plugins: [router] }
+    });
+    await flushPromises();
+
+    // THEN: 9 barres de distribution (notes 2 à 10)
+    const bars = wrapper.findAll('[data-test="distribution-bar"]');
+    expect(bars).toHaveLength(9);
+  });
+
+  it('should display coups de coeur section with note >= 9', async () => {
+    // GIVEN: L'API retourne un critique avec des coups de coeur
+    axios.get.mockResolvedValueOnce({ data: mockCritiqueData });
+
+    // WHEN: Le composant est monté
+    wrapper = mount(CritiqueDetail, {
+      global: { plugins: [router] }
+    });
+    await flushPromises();
+
+    // THEN: La section coups de coeur affiche les bons livres
+    expect(wrapper.text()).toContain('Combats de filles');
+    const coupDeCoeurItems = wrapper.findAll('[data-test="coup-de-coeur-item"]');
+    expect(coupDeCoeurItems.length).toBeGreaterThanOrEqual(1);
+  });
+
+  it('should display all oeuvres in the list', async () => {
+    // GIVEN: L'API retourne un critique avec 3 oeuvres
+    axios.get.mockResolvedValueOnce({ data: mockCritiqueData });
+
+    // WHEN: Le composant est monté
+    wrapper = mount(CritiqueDetail, {
+      global: { plugins: [router] }
+    });
+    await flushPromises();
+
+    // THEN: Les 3 oeuvres sont affichées
+    const oeuvreItems = wrapper.findAll('[data-test="oeuvre-item"]');
+    expect(oeuvreItems).toHaveLength(3);
+    expect(wrapper.text()).toContain('Combats de filles');
+    expect(wrapper.text()).toContain('Le Grand Vertige');
+    expect(wrapper.text()).toContain('La Vie nouvelle');
+  });
+
+  it('should filter oeuvres by text search', async () => {
+    // GIVEN: Le composant est monté avec des données
+    axios.get.mockResolvedValueOnce({ data: mockCritiqueData });
+    wrapper = mount(CritiqueDetail, {
+      global: { plugins: [router] }
+    });
+    await flushPromises();
+
+    // WHEN: On filtre par texte
+    wrapper.vm.searchFilter = 'Combats';
+    await wrapper.vm.$nextTick();
+
+    // THEN: Seule l'oeuvre correspondante est dans filteredOeuvres
+    expect(wrapper.vm.filteredOeuvres).toHaveLength(1);
+    expect(wrapper.vm.filteredOeuvres[0].livre_titre).toBe('Combats de filles');
+  });
+
+  it('should filter oeuvres by note range', async () => {
+    // GIVEN: Le composant est monté avec des données
+    axios.get.mockResolvedValueOnce({ data: mockCritiqueData });
+    wrapper = mount(CritiqueDetail, {
+      global: { plugins: [router] }
+    });
+    await flushPromises();
+
+    // WHEN: On filtre par note >= 9 (excellent)
+    wrapper.vm.noteFilter = 'excellent';
+    await wrapper.vm.$nextTick();
+
+    // THEN: Seule l'oeuvre avec note 9 est affichée
+    expect(wrapper.vm.filteredOeuvres).toHaveLength(1);
+    expect(wrapper.vm.filteredOeuvres[0].note).toBe(9);
+  });
+
+  it('should call API with correct critique ID from route', async () => {
+    // GIVEN: L'API est mockée
+    axios.get.mockResolvedValueOnce({ data: mockCritiqueData });
+
+    // WHEN: Le composant est monté
+    wrapper = mount(CritiqueDetail, {
+      global: { plugins: [router] }
+    });
+    await flushPromises();
+
+    // THEN: L'API est appelée avec le bon ID et une URL relative
+    const callUrl = axios.get.mock.calls[0][0];
+    expect(callUrl).toBe('/api/critique/694eb58bffd25d11ce052759'); // pragma: allowlist secret
+    expect(callUrl).not.toContain('http://');
+    expect(callUrl).not.toContain('localhost');
+  });
+
+  it('should display empty state when critique has no avis', async () => {
+    // GIVEN: Un critique sans avis
+    const critiqueSansAvis = {
+      ...mockCritiqueData,
+      nombre_avis: 0,
+      note_moyenne: null,
+      note_distribution: {
+        '2': 0, '3': 0, '4': 0, '5': 0,
+        '6': 0, '7': 0, '8': 0, '9': 0, '10': 0
+      },
+      coups_de_coeur: [],
+      oeuvres: []
+    };
+    axios.get.mockResolvedValueOnce({ data: critiqueSansAvis });
+
+    // WHEN: Le composant est monté
+    wrapper = mount(CritiqueDetail, {
+      global: { plugins: [router] }
+    });
+    await flushPromises();
+
+    // THEN: Un message d'état vide est affiché
+    expect(wrapper.text()).toContain('Aucun avis');
+  });
+});

--- a/tests/test_critique_detail.py
+++ b/tests/test_critique_detail.py
@@ -1,0 +1,203 @@
+"""Tests for GET /api/critique/{critique_id} endpoint (Issue #191)."""
+
+from unittest.mock import patch
+
+import pytest
+from bson import ObjectId
+from fastapi.testclient import TestClient
+
+from back_office_lmelp.app import app
+
+
+@pytest.fixture
+def client():
+    """Create a test client."""
+    return TestClient(app)
+
+
+class TestGetCritiqueDetail:
+    """Tests pour l'endpoint GET /api/critique/{critique_id}."""
+
+    @patch("back_office_lmelp.app.mongodb_service")
+    def test_get_critique_returns_info_with_stats_and_oeuvres(
+        self, mock_mongodb_service, client
+    ):
+        """Test que GET /api/critique/{id} retourne les détails avec stats et oeuvres."""
+        # GIVEN: Un critique avec des avis en base
+        critique_id = str(ObjectId())
+        mock_mongodb_service.get_critique_detail.return_value = {
+            "critique_id": critique_id,
+            "nom": "Arnaud Viviant",
+            "animateur": False,
+            "variantes": ["Arnaud Vivian"],
+            "nombre_avis": 2,
+            "note_moyenne": 8.5,
+            "note_distribution": {
+                "2": 0,
+                "3": 0,
+                "4": 0,
+                "5": 0,
+                "6": 0,
+                "7": 0,
+                "8": 1,
+                "9": 1,
+                "10": 0,
+            },
+            "coups_de_coeur": [
+                {
+                    "livre_oid": str(ObjectId()),
+                    "livre_titre": "Combats de filles",
+                    "auteur_nom": "Rita Bullwinkel",
+                    "auteur_oid": str(ObjectId()),
+                    "editeur": "La Croisée",
+                    "note": 9,
+                    "commentaire": "Très belle découverte",
+                    "section": "programme",
+                    "emission_date": "2026-01-18",
+                    "emission_oid": str(ObjectId()),
+                }
+            ],
+            "oeuvres": [
+                {
+                    "livre_oid": str(ObjectId()),
+                    "livre_titre": "Combats de filles",
+                    "auteur_nom": "Rita Bullwinkel",
+                    "auteur_oid": str(ObjectId()),
+                    "editeur": "La Croisée",
+                    "note": 9,
+                    "commentaire": "Très belle découverte",
+                    "section": "programme",
+                    "emission_date": "2026-01-18",
+                    "emission_oid": str(ObjectId()),
+                },
+                {
+                    "livre_oid": str(ObjectId()),
+                    "livre_titre": "Le Grand Vertige",
+                    "auteur_nom": "Pierre Ducrozet",
+                    "auteur_oid": str(ObjectId()),
+                    "editeur": "Actes Sud",
+                    "note": 8,
+                    "commentaire": "Roman ambitieux",
+                    "section": "programme",
+                    "emission_date": "2025-12-14",
+                    "emission_oid": str(ObjectId()),
+                },
+            ],
+        }
+
+        # WHEN: On appelle GET /api/critique/{id}
+        response = client.get(f"/api/critique/{critique_id}")
+
+        # THEN: On reçoit un 200 avec les données enrichies
+        assert response.status_code == 200
+        data = response.json()
+        assert data["critique_id"] == critique_id
+        assert data["nom"] == "Arnaud Viviant"
+        assert data["animateur"] is False
+        assert data["variantes"] == ["Arnaud Vivian"]
+        assert data["nombre_avis"] == 2
+        assert data["note_moyenne"] == 8.5
+        assert "note_distribution" in data
+        assert data["note_distribution"]["9"] == 1
+        assert data["note_distribution"]["8"] == 1
+        assert len(data["coups_de_coeur"]) == 1
+        assert data["coups_de_coeur"][0]["note"] >= 9
+        assert len(data["oeuvres"]) == 2
+
+        # Vérifier que le service a été appelé avec le bon ID
+        mock_mongodb_service.get_critique_detail.assert_called_once_with(critique_id)
+
+    @patch("back_office_lmelp.app.mongodb_service")
+    def test_get_critique_returns_404_when_not_found(
+        self, mock_mongodb_service, client
+    ):
+        """Test que GET /api/critique/{id} retourne 404 si le critique n'existe pas."""
+        # GIVEN: Un critique inexistant
+        critique_id = str(ObjectId())
+        mock_mongodb_service.get_critique_detail.return_value = None
+
+        # WHEN: On appelle GET /api/critique/{id}
+        response = client.get(f"/api/critique/{critique_id}")
+
+        # THEN: On reçoit un 404
+        assert response.status_code == 404
+        assert "Critique non trouvé" in response.json()["detail"]
+
+    @patch("back_office_lmelp.app.mongodb_service")
+    def test_get_critique_validates_objectid_format(self, mock_mongodb_service, client):
+        """Test que l'endpoint valide le format ObjectId."""
+        # GIVEN: Un ID invalide (trop court)
+        invalid_id = "invalid_id_format"
+
+        # WHEN: On appelle GET /api/critique/{invalid_id}
+        response = client.get(f"/api/critique/{invalid_id}")
+
+        # THEN: On reçoit une erreur 404
+        assert response.status_code == 404
+        assert "Critique non trouvé" in response.json()["detail"]
+
+    @patch("back_office_lmelp.app.mongodb_service")
+    def test_get_critique_returns_critique_with_no_avis(
+        self, mock_mongodb_service, client
+    ):
+        """Test qu'un critique sans avis retourne des listes vides et stats null."""
+        # GIVEN: Un critique sans aucun avis
+        critique_id = str(ObjectId())
+        mock_mongodb_service.get_critique_detail.return_value = {
+            "critique_id": critique_id,
+            "nom": "Nouveau Critique",
+            "animateur": False,
+            "variantes": [],
+            "nombre_avis": 0,
+            "note_moyenne": None,
+            "note_distribution": {
+                "2": 0,
+                "3": 0,
+                "4": 0,
+                "5": 0,
+                "6": 0,
+                "7": 0,
+                "8": 0,
+                "9": 0,
+                "10": 0,
+            },
+            "coups_de_coeur": [],
+            "oeuvres": [],
+        }
+
+        # WHEN: On appelle GET /api/critique/{id}
+        response = client.get(f"/api/critique/{critique_id}")
+
+        # THEN: On reçoit un 200 avec des listes vides
+        assert response.status_code == 200
+        data = response.json()
+        assert data["nombre_avis"] == 0
+        assert data["note_moyenne"] is None
+        assert data["coups_de_coeur"] == []
+        assert data["oeuvres"] == []
+
+    @patch("back_office_lmelp.app.mongodb_service")
+    def test_get_critique_returns_animateur_flag(self, mock_mongodb_service, client):
+        """Test que le flag animateur est correctement retourné."""
+        # GIVEN: Un critique qui est aussi animateur
+        critique_id = str(ObjectId())
+        mock_mongodb_service.get_critique_detail.return_value = {
+            "critique_id": critique_id,
+            "nom": "Jérôme Garcin",
+            "animateur": True,
+            "variantes": [],
+            "nombre_avis": 100,
+            "note_moyenne": 7.0,
+            "note_distribution": {str(i): 0 for i in range(2, 11)},
+            "coups_de_coeur": [],
+            "oeuvres": [],
+        }
+
+        # WHEN: On appelle GET /api/critique/{id}
+        response = client.get(f"/api/critique/{critique_id}")
+
+        # THEN: Le flag animateur est True
+        assert response.status_code == 200
+        data = response.json()
+        assert data["animateur"] is True
+        assert data["nom"] == "Jérôme Garcin"


### PR DESCRIPTION
## Summary
- Add `GET /api/critique/{critique_id}` endpoint that aggregates critique profile, note statistics, distribution, coups de coeur, and enriched oeuvres list
- Create `CritiqueDetail.vue` page with CSS-only barplot for note distribution (notes 2-10), coups de coeur section, and client-side filterable oeuvres list (text search, note range, section)
- Add lazy-loaded `/critique/:id` route, backend + frontend tests (5 + 11), and documentation updates

## Test plan
- [x] 5 backend tests pass (`tests/test_critique_detail.py`)
- [x] 11 frontend integration tests pass (`frontend/tests/integration/CritiqueDetail.test.js`)
- [x] All 1056 existing backend tests pass
- [x] All 473 existing frontend tests pass
- [x] Pre-commit hooks pass (ruff, mypy, detect-secrets)
- [x] CI/CD pipeline green (security, frontend-tests, test 3.11, test 3.12, quality-gate)
- [x] mkdocs build --strict passes
- [x] Manual testing: navigate to `/critique/:id` from emission page, verify data display, filtering, barplot, navigation links

Closes #191

🤖 Generated with [Claude Code](https://claude.com/claude-code)