### PR TITLE
feat(livre): Add critic reviews on livre detail page (#201)

### DIFF
--- a/docs/claude/memory/260206-2223-issue201-avis-critiques-page-livre.md
+++ b/docs/claude/memory/260206-2223-issue201-avis-critiques-page-livre.md
@@ -1,0 +1,93 @@
+# Issue #201 - Ajouter les avis des critiques sur la page livre
+
+## Résumé
+
+Ajout d'une section "Avis des critiques" sur la page détail livre (`/livre/:id`), affichant les avis individuels des critiques groupés par émission, avec nom du critique, commentaire et note.
+
+## Modifications effectuées
+
+### Backend - Enrichissement endpoint `GET /api/avis/by-livre/{livre_id}`
+
+**Fichier** : `src/back_office_lmelp/app.py:4242-4280`
+
+L'endpoint existant retournait des données minimales (id, emission_oid, critique_oid, commentaire, note, section). Il a été enrichi avec :
+
+- `critique_nom` : nom officiel du critique depuis la collection `critiques` (lookup par ObjectId)
+- `emission_date` : date de l'émission depuis la collection `emissions` (lookup par ObjectId)
+
+Le pattern d'enrichissement suit exactement celui de `get_avis_by_emission` (`app.py:3890-3970`).
+
+**Gestion des types date** : conversion via `isoformat()` si datetime, sinon `str()` pour les dates string.
+
+### Frontend - Service API
+
+**Fichier** : `frontend/src/services/api.js`
+
+Ajout de `getAvisByLivre(livreId)` dans `avisService` - appel `GET /api/avis/by-livre/{livreId}`.
+
+### Frontend - Page détail livre
+
+**Fichier** : `frontend/src/views/LivreDetail.vue`
+
+**Données** :
+- Nouveau champ `avis: []` dans `data()`
+- Chargement parallèle dans `mounted()` avec `Promise.all([loadLivre(), loadAnnasArchiveUrl(), loadAvis()])`
+- Nouvelle méthode `loadAvis()` avec gestion silencieuse des erreurs (les avis ne sont pas critiques)
+
+**Computed property `avisGrouped`** :
+- Groupe les avis par `emission_oid`
+- Trie les groupes par date décroissante
+- Trie les avis dans chaque groupe par nom de critique (alphabétique)
+- Extrait `emission_date_raw` (YYYY-MM-DD) pour les liens vers `/emissions/:date`
+
+**Template** :
+- Section conditionnelle (`v-if="avisGrouped.length > 0"`) après la liste des émissions
+- Un bloc par émission avec header contenant la date (lien vers la page émission)
+- Tableau par émission : Critique | Commentaire | Note
+- Lien vers `/critique/:id` si le critique est résolu
+- Badge de note coloré (noteClass réutilisé)
+- `data-test="avis-critiques-section"`, `data-test="avis-emission-group"`, `data-test="avis-row"` pour les tests
+
+### Tests backend
+
+**Fichier** : `tests/test_livre_avis_critiques.py` (nouveau, 4 tests)
+
+- `test_enriched_response_includes_critique_nom` : vérifie l'enrichissement avec le nom officiel du critique
+- `test_enriched_response_includes_emission_date` : vérifie la présence de la date d'émission
+- `test_response_with_no_avis_returns_empty_list` : cas vide
+- `test_unresolved_critique_has_no_critique_nom` : critique non résolu n'a pas de `critique_nom`
+
+**Fichier** : `tests/test_api_avis_endpoints.py` (modifié)
+
+Mise à jour de `TestGetAvisByLivre::test_get_avis_by_livre_returns_list` pour utiliser des ObjectIds valides au lieu de chaînes arbitraires (l'enrichissement fait `ObjectId(critique_oid)` qui échoue sur "critique1").
+
+### Tests frontend
+
+**Fichier** : `frontend/src/views/__tests__/LivreDetail.spec.js` (nouveau, 3 tests)
+
+- `should display avis section when avis exist` : vérifie que la section et les données s'affichent
+- `should not display avis section when no avis` : vérifie l'absence via `data-test` (pas via texte, car le commentaire HTML `<!-- Avis des critiques -->` est toujours rendu par Vue)
+- `should group avis by emission date` : vérifie le groupement et le formatage des dates
+
+## Points techniques notables
+
+### Pattern d'enrichissement API
+
+L'enrichissement se fait en boucle sur chaque avis avec des lookups individuels (même pattern que `get_avis_by_emission`). Pour un grand nombre d'avis, une optimisation par batch pourrait être envisagée (collecter tous les IDs distincts, faire un seul find, puis mapper).
+
+### Test v-if et commentaires HTML Vue
+
+Leçon : `expect(html).not.toContain('Avis des critiques')` échoue même quand la section est masquée par `v-if`, car Vue rend les commentaires HTML du template (`<!-- Avis des critiques -->`). Utiliser `wrapper.find('[data-test="..."]').exists()` pour tester la présence/absence conditionnelle.
+
+### Mocks avec ObjectIds valides
+
+Les mocks de tests d'API qui passent par des lookups `ObjectId()` doivent utiliser des ObjectIds valides (24 hex chars). L'utilisation de chaînes arbitraires comme "em1" ou "critique1" cause des `bson.errors.InvalidId`.
+
+## Fichiers modifiés
+
+- `src/back_office_lmelp/app.py` - enrichissement endpoint avis by livre
+- `frontend/src/services/api.js` - ajout `getAvisByLivre`
+- `frontend/src/views/LivreDetail.vue` - section avis + computed + styles
+- `tests/test_api_avis_endpoints.py` - fix mocks ObjectIds
+- `tests/test_livre_avis_critiques.py` - nouveaux tests enrichissement
+- `frontend/src/views/__tests__/LivreDetail.spec.js` - nouveaux tests frontend

--- a/docs/user/detail-pages.md
+++ b/docs/user/detail-pages.md
@@ -89,15 +89,29 @@ Dans la page **Livres et Auteurs** (`/livres-auteurs`), les auteurs et titres va
 └─────────────────────────────────────────────────────────────┘
 
 ┌─────────────────────────────────────────────────────────────┐
-│  Épisodes :                                                  │
+│  Émissions présentant "L'Étranger" :                         │
 │                                                              │
-│  📺 Les nouvelles pages du polar                            │
-│      📅 12/01/2025                                           │
-│      ⭐ Au programme                                         │
+│  📅 12 janvier 2025  · 3 avis  · ⭐ 7.5                     │
+│  📅  5 septembre 2024  · 2 avis  · ⭐ 8.0                   │
+└─────────────────────────────────────────────────────────────┘
+
+┌─────────────────────────────────────────────────────────────┐
+│  Avis des critiques                                          │
 │                                                              │
-│  📺 Spécial rentrée littéraire                              │
-│      📅 05/09/2024                                           │
-│      💙 Coup de cœur                                         │
+│  📅 12 janvier 2025                                          │
+│  ┌────────────┬──────────────────────┬──────┐               │
+│  │ Critique   │ Commentaire          │ Note │               │
+│  ├────────────┼──────────────────────┼──────┤               │
+│  │ A. Viviant │ Impressionnant       │  8   │               │
+│  │ E. Philippe│ Très belle découverte│  9   │               │
+│  └────────────┴──────────────────────┴──────┘               │
+│                                                              │
+│  📅 5 septembre 2024                                         │
+│  ┌────────────┬──────────────────────┬──────┐               │
+│  │ Critique   │ Commentaire          │ Note │               │
+│  ├────────────┼──────────────────────┼──────┤               │
+│  │ A. Viviant │ Remarquable          │  7   │               │
+│  └────────────┴──────────────────────┴──────┘               │
 └─────────────────────────────────────────────────────────────┘
 ```
 
@@ -116,10 +130,16 @@ Dans la page **Livres et Auteurs** (`/livres-auteurs`), les auteurs et titres va
     - Tag de bibliothèque virtuelle (ex: `guillaume`) : affiché en premier si le livre est présent dans Calibre
     - Un bouton 📋 permet de copier tous les tags (séparés par des virgules) dans le presse-papier. Le bouton affiche ✓ pendant 2 secondes après la copie
     - Si aucun tag n'est disponible, cette section n'est pas affichée
-- **Liste des épisodes** : Tous les épisodes mentionnant ce livre
-  - Titre de l'épisode
-  - Date de diffusion
-  - Type de mention (Au programme / Coup de cœur)
+- **Liste des émissions** : Toutes les émissions mentionnant ce livre
+  - Date de l'émission (clickable vers la page émission)
+  - Nombre d'avis et note moyenne par émission
+- **Avis des critiques** : Les avis individuels des critiques, groupés par émission
+  - Section affichée uniquement si des avis structurés existent pour ce livre
+  - Chaque émission forme un groupe avec sa date en en-tête
+  - Tableau par groupe : Critique, Commentaire, Note
+  - Les noms de critiques sont clickables vers la page critique (si résolu)
+  - Les dates d'émission sont clickables vers la page émission
+  - Les notes sont colorées selon le barème habituel (vert >= 9, jaune-vert >= 7, etc.)
 
 ### Actions disponibles
 
@@ -127,7 +147,8 @@ Dans la page **Livres et Auteurs** (`/livres-auteurs`), les auteurs et titres va
 - **Cliquer sur l'icône Anna's Archive** : Recherche du livre (titre + auteur) sur Anna's Archive (nouvel onglet)
 - **Cliquer sur l'auteur** : Accès à la page détail de cet auteur
 - **Copier les tags Calibre** : Bouton 📋 copie tous les tags séparés par des virgules dans le presse-papier
-- **Cliquer sur un épisode** : Navigation vers la validation bibliographique avec l'épisode pré-sélectionné
+- **Cliquer sur une émission** : Navigation vers la page émission correspondante
+- **Cliquer sur un critique** : Accès à la page détail du critique
 - **Retour au Dashboard** : Bouton "🏠 Accueil" en haut de page
 
 ## Page Détail Critique

--- a/frontend/src/services/api.js
+++ b/frontend/src/services/api.js
@@ -564,6 +564,16 @@ export const avisService = {
   },
 
   /**
+   * Récupère les avis d'un livre
+   * @param {string} livreId - ID du livre
+   * @returns {Promise<Object>} Liste des avis {avis: [...]}
+   */
+  async getAvisByLivre(livreId) {
+    const response = await api.get(`/avis/by-livre/${livreId}`);
+    return response.data;
+  },
+
+  /**
    * Extrait les avis depuis le summary d'une émission
    * @param {string} emissionId - ID de l'émission
    * @returns {Promise<Object>} Résultat de l'extraction

--- a/frontend/src/views/__tests__/LivreDetail.spec.js
+++ b/frontend/src/views/__tests__/LivreDetail.spec.js
@@ -1,0 +1,201 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { mount } from '@vue/test-utils';
+import LivreDetail from '../LivreDetail.vue';
+import axios from 'axios';
+
+// Mock axios
+vi.mock('axios', () => ({
+  default: {
+    get: vi.fn(),
+  },
+}));
+
+// Mock router
+const mockRoute = {
+  params: { id: '507f1f77bcf86cd799439011' }, // pragma: allowlist secret
+};
+
+const mockRouter = {
+  back: vi.fn(),
+};
+
+describe('LivreDetail - Avis des critiques (Issue #201)', () => {
+  beforeEach(() => {
+    vi.resetAllMocks();
+  });
+
+  function mountComponent() {
+    return mount(LivreDetail, {
+      global: {
+        mocks: {
+          $route: mockRoute,
+          $router: mockRouter,
+        },
+        stubs: {
+          'router-link': {
+            template: '<a><slot /></a>',
+            props: ['to'],
+          },
+          Navigation: { template: '<div />' },
+        },
+      },
+    });
+  }
+
+  it('should display avis section when avis exist', async () => {
+    // Mock livre response
+    axios.get.mockImplementation((url) => {
+      if (url.includes('/api/livre/')) {
+        return Promise.resolve({
+          data: {
+            livre_id: '507f1f77bcf86cd799439011',
+            titre: 'Love me tender',
+            auteur_id: '507f1f77bcf86cd799439012',
+            auteur_nom: 'Constance Debré',
+            editeur: 'Flammarion',
+            note_moyenne: 7.5,
+            nombre_emissions: 1,
+            emissions: [],
+          },
+        });
+      }
+      if (url.includes('/api/avis/by-livre/')) {
+        return Promise.resolve({
+          data: {
+            avis: [
+              {
+                id: 'avis1',
+                emission_oid: 'em1',
+                critique_oid: 'crit1',
+                critique_nom: 'Arnaud Viviant',
+                critique_nom_extrait: 'Arnaud Viviant',
+                commentaire: 'Impressionnant',
+                note: 8,
+                section: 'programme',
+                emission_date: '2025-01-26T00:00:00.000Z',
+              },
+              {
+                id: 'avis2',
+                emission_oid: 'em1',
+                critique_nom_extrait: 'Elisabeth Philippe',
+                commentaire: 'Très beau',
+                note: 9,
+                section: 'programme',
+                emission_date: '2025-01-26T00:00:00.000Z',
+              },
+            ],
+          },
+        });
+      }
+      if (url.includes('/api/config/annas-archive-url')) {
+        return Promise.resolve({ data: { url: 'https://fr.annas-archive.org' } });
+      }
+      return Promise.reject(new Error(`Unexpected URL: ${url}`));
+    });
+
+    const wrapper = mountComponent();
+    await wrapper.vm.$nextTick();
+    // Wait for async mounted
+    await new Promise((resolve) => setTimeout(resolve, 50));
+
+    const html = wrapper.html();
+    expect(html).toContain('Avis des critiques');
+    expect(html).toContain('Arnaud Viviant');
+    expect(html).toContain('Impressionnant');
+  });
+
+  it('should not display avis section when no avis', async () => {
+    axios.get.mockImplementation((url) => {
+      if (url.includes('/api/livre/')) {
+        return Promise.resolve({
+          data: {
+            livre_id: '507f1f77bcf86cd799439011',
+            titre: 'Livre sans avis',
+            auteur_id: '507f1f77bcf86cd799439012',
+            auteur_nom: 'Auteur Test',
+            editeur: 'Éditeur',
+            note_moyenne: null,
+            nombre_emissions: 0,
+            emissions: [],
+          },
+        });
+      }
+      if (url.includes('/api/avis/by-livre/')) {
+        return Promise.resolve({ data: { avis: [] } });
+      }
+      if (url.includes('/api/config/annas-archive-url')) {
+        return Promise.resolve({ data: { url: 'https://fr.annas-archive.org' } });
+      }
+      return Promise.reject(new Error(`Unexpected URL: ${url}`));
+    });
+
+    const wrapper = mountComponent();
+    await wrapper.vm.$nextTick();
+    await new Promise((resolve) => setTimeout(resolve, 50));
+
+    expect(wrapper.find('[data-test="avis-critiques-section"]').exists()).toBe(false);
+  });
+
+  it('should group avis by emission date', async () => {
+    axios.get.mockImplementation((url) => {
+      if (url.includes('/api/livre/')) {
+        return Promise.resolve({
+          data: {
+            livre_id: '507f1f77bcf86cd799439011',
+            titre: 'Multi-emission book',
+            auteur_id: '507f1f77bcf86cd799439012',
+            auteur_nom: 'Auteur Test',
+            editeur: 'Éditeur',
+            note_moyenne: 8.0,
+            nombre_emissions: 2,
+            emissions: [],
+          },
+        });
+      }
+      if (url.includes('/api/avis/by-livre/')) {
+        return Promise.resolve({
+          data: {
+            avis: [
+              {
+                id: 'avis1',
+                emission_oid: 'em1',
+                critique_nom: 'Critique A',
+                critique_nom_extrait: 'Critique A',
+                commentaire: 'Avis 1',
+                note: 8,
+                section: 'programme',
+                emission_date: '2025-01-26T00:00:00.000Z',
+              },
+              {
+                id: 'avis2',
+                emission_oid: 'em2',
+                critique_nom: 'Critique B',
+                critique_nom_extrait: 'Critique B',
+                commentaire: 'Avis 2',
+                note: 7,
+                section: 'programme',
+                emission_date: '2024-12-15T00:00:00.000Z',
+              },
+            ],
+          },
+        });
+      }
+      if (url.includes('/api/config/annas-archive-url')) {
+        return Promise.resolve({ data: { url: 'https://fr.annas-archive.org' } });
+      }
+      return Promise.reject(new Error(`Unexpected URL: ${url}`));
+    });
+
+    const wrapper = mountComponent();
+    await wrapper.vm.$nextTick();
+    await new Promise((resolve) => setTimeout(resolve, 50));
+
+    // Should have avis grouped - verify both critics appear
+    const html = wrapper.html();
+    expect(html).toContain('Critique A');
+    expect(html).toContain('Critique B');
+    // Should show emission dates
+    expect(html).toContain('26 janvier 2025');
+    expect(html).toContain('15 décembre 2024');
+  });
+});

--- a/tests/test_api_avis_endpoints.py
+++ b/tests/test_api_avis_endpoints.py
@@ -449,13 +449,25 @@ class TestGetAvisByLivre:
     def test_get_avis_by_livre_returns_list(self):
         """Test que GET retourne la liste des avis du livre."""
         livre_id = str(ObjectId())
+        emission_id = ObjectId()
+        critique_id = ObjectId()
 
         self.mock_mongodb.avis_collection = MagicMock()
+        self.mock_mongodb.critiques_collection = MagicMock()
+        self.mock_mongodb.emissions_collection = MagicMock()
+        self.mock_mongodb.critiques_collection.find_one.return_value = {
+            "_id": critique_id,
+            "nom": "Critique Test",
+        }
+        self.mock_mongodb.emissions_collection.find_one.return_value = {
+            "_id": emission_id,
+            "date": "2025-01-01T00:00:00.000Z",
+        }
         self.mock_mongodb.get_avis_by_livre.return_value = [
             {
                 "_id": ObjectId(),
-                "emission_oid": "em1",
-                "critique_oid": "critique1",
+                "emission_oid": str(emission_id),
+                "critique_oid": str(critique_id),
                 "critique_nom_extrait": "Critique Test",
                 "commentaire": "Excellent",
                 "note": 10,

--- a/tests/test_livre_avis_critiques.py
+++ b/tests/test_livre_avis_critiques.py
@@ -1,0 +1,164 @@
+"""Tests for enriched GET /api/avis/by-livre/{livre_id} endpoint (Issue #201).
+
+The endpoint should return critic reviews for a book, enriched with
+critic names and emission dates for display on the livre detail page.
+"""
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+from bson import ObjectId
+from fastapi.testclient import TestClient
+
+from back_office_lmelp.app import app
+
+
+@pytest.fixture
+def client():
+    """Create a test client."""
+    return TestClient(app)
+
+
+class TestAvisByLivreEnriched:
+    """Tests for enriched avis data in GET /api/avis/by-livre/{livre_id}."""
+
+    @patch("back_office_lmelp.app.mongodb_service")
+    def test_enriched_response_includes_critique_nom(
+        self, mock_mongodb_service, client
+    ):
+        """Test that response includes official critic name when resolved."""
+        livre_id = str(ObjectId())
+        critique_id = ObjectId()
+        emission_id = ObjectId()
+
+        # Mock the service method (not the collection directly)
+        mock_mongodb_service.avis_collection = MagicMock()
+        mock_mongodb_service.get_avis_by_livre.return_value = [
+            {
+                "_id": ObjectId(),
+                "emission_oid": str(emission_id),
+                "livre_oid": livre_id,
+                "critique_oid": str(critique_id),
+                "critique_nom_extrait": "Arnaud Viviant",
+                "commentaire": "Impressionnant",
+                "note": 8,
+                "section": "programme",
+            }
+        ]
+
+        # Mock critiques collection for enrichment
+        mock_mongodb_service.critiques_collection = MagicMock()
+        mock_mongodb_service.critiques_collection.find_one.return_value = {
+            "_id": critique_id,
+            "nom": "Arnaud Viviant",
+        }
+
+        # Mock emissions collection for enrichment
+        mock_mongodb_service.emissions_collection = MagicMock()
+        mock_mongodb_service.emissions_collection.find_one.return_value = {
+            "_id": emission_id,
+            "date": "2025-01-26T00:00:00.000Z",
+        }
+
+        response = client.get(f"/api/avis/by-livre/{livre_id}")
+        assert response.status_code == 200
+        data = response.json()
+
+        assert len(data["avis"]) == 1
+        avis = data["avis"][0]
+        assert avis["critique_nom"] == "Arnaud Viviant"
+        assert avis["emission_date"] is not None
+
+    @patch("back_office_lmelp.app.mongodb_service")
+    def test_enriched_response_includes_emission_date(
+        self, mock_mongodb_service, client
+    ):
+        """Test that response includes emission date for grouping."""
+        livre_id = str(ObjectId())
+        emission_id = ObjectId()
+
+        mock_mongodb_service.avis_collection = MagicMock()
+        mock_mongodb_service.get_avis_by_livre.return_value = [
+            {
+                "_id": ObjectId(),
+                "emission_oid": str(emission_id),
+                "livre_oid": livre_id,
+                "critique_oid": None,
+                "critique_nom_extrait": "Test Critique",
+                "commentaire": "Bon livre",
+                "note": 7,
+                "section": "programme",
+            }
+        ]
+
+        mock_mongodb_service.critiques_collection = MagicMock()
+
+        # Mock emissions lookup
+        mock_mongodb_service.emissions_collection = MagicMock()
+        mock_mongodb_service.emissions_collection.find_one.return_value = {
+            "_id": emission_id,
+            "date": "2024-12-15T00:00:00.000Z",
+        }
+
+        response = client.get(f"/api/avis/by-livre/{livre_id}")
+        assert response.status_code == 200
+        data = response.json()
+
+        avis = data["avis"][0]
+        assert "emission_date" in avis
+        assert "2024-12-15" in avis["emission_date"]
+
+    @patch("back_office_lmelp.app.mongodb_service")
+    def test_response_with_no_avis_returns_empty_list(
+        self, mock_mongodb_service, client
+    ):
+        """Test that a book with no avis returns empty list."""
+        livre_id = str(ObjectId())
+
+        mock_mongodb_service.avis_collection = MagicMock()
+        mock_mongodb_service.get_avis_by_livre.return_value = []
+        mock_mongodb_service.critiques_collection = MagicMock()
+        mock_mongodb_service.emissions_collection = MagicMock()
+
+        response = client.get(f"/api/avis/by-livre/{livre_id}")
+        assert response.status_code == 200
+        data = response.json()
+
+        assert data["avis"] == []
+
+    @patch("back_office_lmelp.app.mongodb_service")
+    def test_unresolved_critique_has_no_critique_nom(
+        self, mock_mongodb_service, client
+    ):
+        """Test that avis with no critique_oid has no critique_nom field."""
+        livre_id = str(ObjectId())
+        emission_id = ObjectId()
+
+        mock_mongodb_service.avis_collection = MagicMock()
+        mock_mongodb_service.get_avis_by_livre.return_value = [
+            {
+                "_id": ObjectId(),
+                "emission_oid": str(emission_id),
+                "livre_oid": livre_id,
+                "critique_oid": None,
+                "critique_nom_extrait": "Critique Inconnu",
+                "commentaire": "Pas mal",
+                "note": 6,
+                "section": "programme",
+            }
+        ]
+
+        mock_mongodb_service.critiques_collection = MagicMock()
+        mock_mongodb_service.emissions_collection = MagicMock()
+        mock_mongodb_service.emissions_collection.find_one.return_value = {
+            "_id": emission_id,
+            "date": "2025-03-01T00:00:00.000Z",
+        }
+
+        response = client.get(f"/api/avis/by-livre/{livre_id}")
+        assert response.status_code == 200
+        data = response.json()
+
+        avis = data["avis"][0]
+        assert "critique_nom" not in avis
+        assert avis["critique_nom_extrait"] == "Critique Inconnu"


### PR DESCRIPTION
## Summary
- Add "Avis des critiques" section on the livre detail page displaying individual critic reviews grouped by emission date
- Enrich `GET /api/avis/by-livre/{id}` endpoint with `critique_nom` and `emission_date` fields
- Each emission group shows a table with Critique, Commentaire, and Note columns with color-coded ratings and clickable links

## Test plan
- [ ] Backend tests: 4 new tests in `tests/test_livre_avis_critiques.py` verify enriched API response
- [ ] Frontend tests: 3 new tests in `frontend/src/views/__tests__/LivreDetail.spec.js` verify avis display and grouping
- [ ] Existing test fix: Updated `test_api_avis_endpoints.py` to use valid ObjectIds
- [ ] Visual test: Navigate to a livre page with critic reviews and verify display
- [ ] CI/CD: All checks pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)