### PR TITLE
fix: resolve search ObjectId serialization and editeur enrichment (#208)

### DIFF
--- a/docs/claude/memory/260210-1724-issue208-search-editeur-serialization.md
+++ b/docs/claude/memory/260210-1724-issue208-search-editeur-serialization.md
@@ -1,0 +1,37 @@
+# Issue #208 - Bug recherche simple/avancée + éditeur émission
+
+## Problème 1 : PydanticSerializationError dans la recherche
+
+**Symptôme** : Erreur 500 sur `/api/search` et `/api/advanced-search` lors de la recherche de livres ayant un champ `editeur_id` (ObjectId).
+
+**Cause** : `search_livres()` dans `mongodb_service.py` convertissait `_id` et `auteur_id` en string, mais pas `editeur_id`. Ce champ existe sur 12 documents suite à la migration Issue #189.
+
+**Fix** : Ajout de la conversion `editeur_id` → string dans `search_livres()` (`mongodb_service.py:762-763`).
+
+**Leçon** : Quand un champ ObjectId est ajouté par migration (comme `editeur_id`), il faut mettre à jour TOUTES les méthodes qui sérialisent les documents de cette collection.
+
+## Problème 2 : Éditeur incohérent entre pages émission et détail livre
+
+**Symptôme** : La page émission affichait "POL" (extrait LLM) alors que le détail livre affichait "P.O.L." (valeur MongoDB officielle).
+
+**Cause** : L'endpoint `GET /api/avis/by-emission` enrichissait `livre_titre` et `auteur_nom` depuis la collection `livres`, mais pas l'éditeur. Le frontend `AvisTable.vue` utilisait uniquement `editeur_extrait` sans fallback.
+
+**Fix** :
+- Backend (`app.py:4144-4146`) : Ajout enrichissement `editeur` depuis le livre résolu dans l'endpoint avis
+- Frontend (`AvisTable.vue:270`) : Pattern fallback `avis.editeur || avis.editeur_extrait` (même pattern que titre et auteur)
+
+## Fichiers modifiés
+
+- `src/back_office_lmelp/services/mongodb_service.py` : Conversion `editeur_id` ObjectId → string
+- `src/back_office_lmelp/app.py` : Enrichissement éditeur dans endpoint avis
+- `frontend/src/components/AvisTable.vue` : Fallback éditeur officiel/extrait
+- `tests/test_search_service.py` : Test RED/GREEN avec vrais ObjectId
+- `tests/test_api_avis_endpoints.py` : Test enrichissement éditeur
+- `frontend/tests/unit/AvisTableEditeur.test.js` : Test fallback frontend
+
+## Pattern à retenir
+
+Pour l'enrichissement des avis dans `/api/avis/by-emission`, le pattern est :
+1. Backend : enrichir avec les données officielles MongoDB quand `livre_oid` est résolu
+2. Frontend : utiliser `champ_officiel || champ_extrait` comme fallback
+3. Champs enrichis : `livre_titre`, `auteur_nom`, `editeur` (ajouté par ce fix)

--- a/frontend/src/components/AvisTable.vue
+++ b/frontend/src/components/AvisTable.vue
@@ -266,7 +266,8 @@ export default {
             titre: avis.livre_titre || avis.livre_titre_extrait,
             // auteur_nom = nom officiel MongoDB (enrichi par l'API), sinon fallback sur nom extrait
             auteur: avis.auteur_nom || avis.auteur_nom_extrait,
-            editeur: avis.editeur_extrait,
+            // editeur = éditeur officiel MongoDB (enrichi par l'API), sinon fallback sur éditeur extrait
+            editeur: avis.editeur || avis.editeur_extrait,
             livre_oid: avis.livre_oid,
             auteur_oid: avis.auteur_oid,
             avis: [],

--- a/frontend/tests/unit/AvisTableEditeur.test.js
+++ b/frontend/tests/unit/AvisTableEditeur.test.js
@@ -1,0 +1,76 @@
+/**
+ * Tests pour le composant AvisTable - enrichissement éditeur.
+ *
+ * Vérifie que l'éditeur officiel MongoDB est utilisé en priorité
+ * sur l'éditeur extrait par le LLM (Issue #208).
+ */
+import { describe, it, expect } from 'vitest';
+import { mount } from '@vue/test-utils';
+import AvisTable from '@/components/AvisTable.vue';
+
+describe('AvisTable - editeur enrichment', () => {
+  it('should use editeur officiel over editeur_extrait when available', () => {
+    const wrapper = mount(AvisTable, {
+      props: {
+        avis: [
+          {
+            id: '1',
+            section: 'programme',
+            livre_oid: 'livre123',
+            livre_titre: 'Kolkhoze',
+            livre_titre_extrait: 'Kolkhoze',
+            auteur_nom: 'Emmanuel Carrère',
+            auteur_nom_extrait: 'Emmanuel Carrère',
+            editeur: 'P.O.L.',
+            editeur_extrait: 'POL',
+            critique_nom_extrait: 'Laurent Chalumeau',
+            commentaire: 'Virtuose',
+            note: 9,
+          },
+        ],
+      },
+      global: {
+        stubs: {
+          'router-link': {
+            template: '<a><slot /></a>',
+          },
+        },
+      },
+    });
+
+    // Vérifier que l'éditeur officiel est affiché, pas l'extrait LLM
+    const editeurCell = wrapper.find('.editeur-cell');
+    expect(editeurCell.text()).toBe('P.O.L.');
+  });
+
+  it('should fallback to editeur_extrait when editeur officiel is not available', () => {
+    const wrapper = mount(AvisTable, {
+      props: {
+        avis: [
+          {
+            id: '2',
+            section: 'programme',
+            livre_oid: null,
+            livre_titre_extrait: 'Un Livre',
+            auteur_nom_extrait: 'Un Auteur',
+            editeur_extrait: 'Gallimard',
+            critique_nom_extrait: 'Un Critique',
+            commentaire: 'Bien',
+            note: 7,
+          },
+        ],
+      },
+      global: {
+        stubs: {
+          'router-link': {
+            template: '<a><slot /></a>',
+          },
+        },
+      },
+    });
+
+    // Pas d'éditeur officiel -> fallback sur editeur_extrait
+    const editeurCell = wrapper.find('.editeur-cell');
+    expect(editeurCell.text()).toBe('Gallimard');
+  });
+});

--- a/src/back_office_lmelp/app.py
+++ b/src/back_office_lmelp/app.py
@@ -4140,6 +4140,10 @@ async def get_avis_by_emission(emission_id: str) -> JSONResponse:
                 )
                 if livre:
                     enriched["livre_titre"] = livre.get("titre", "")
+                    # Enrichir avec l'éditeur officiel du livre
+                    editeur_officiel = livre.get("editeur", "")
+                    if editeur_officiel:
+                        enriched["editeur"] = editeur_officiel
                     auteur_id = livre.get("auteur_id")
                     if auteur_id:
                         enriched["auteur_oid"] = str(auteur_id)

--- a/src/back_office_lmelp/services/mongodb_service.py
+++ b/src/back_office_lmelp/services/mongodb_service.py
@@ -757,6 +757,10 @@ class MongoDBService:
                     # Convertir auteur_id en string
                     livre["auteur_id"] = str(livre["auteur_id"])
 
+                # Convertir editeur_id en string si présent
+                if "editeur_id" in livre and livre["editeur_id"]:
+                    livre["editeur_id"] = str(livre["editeur_id"])
+
                 results.append(livre)
 
             return {"livres": results, "total_count": total_count}


### PR DESCRIPTION
## Summary
- Fix `PydanticSerializationError` on `/api/search` and `/api/advanced-search` caused by unconverted `editeur_id` ObjectId in `search_livres()`
- Enrich avis with official publisher name from `livres` collection instead of LLM-extracted value (e.g. "P.O.L." instead of "POL")
- Apply consistent fallback pattern `official || extracted` for editeur, matching existing titre/auteur pattern

## Test plan
- [x] Backend test: `test_search_livres_converts_editeur_id_to_string` with real ObjectId types
- [x] Backend test: `test_get_avis_enriches_editeur_from_livre` verifying enrichment
- [x] Frontend test: `AvisTableEditeur.test.js` verifying fallback pattern
- [x] Full backend test suite: 1186 passed
- [x] Full frontend test suite: 541 passed
- [x] Pre-commit: all hooks pass
- [x] CI/CD: all jobs green
- [x] Manual test: search "simone emonet" works, emission page shows "P.O.L."

Closes #208

🤖 Generated with [Claude Code](https://claude.com/claude-code)