### PR TITLE
feat: show Calibre library status on book detail page (#214)

### DIFF
--- a/README.md
+++ b/README.md
@@ -263,7 +263,7 @@ export BABELIO_CACHE_LOG=1
 
 #### Pages de Détail Auteur et Livre
 - 👤 **Page auteur** : `/auteur/:id` - Vue détaillée d'un auteur avec tous ses livres triés alphabétiquement
-- 📖 **Page livre** : `/livre/:id` - Vue détaillée d'un livre avec liste des épisodes où il est mentionné, tags Calibre associés (dates d'émission, coups de coeur) et copie en un clic
+- 📖 **Page livre** : `/livre/:id` - Vue détaillée d'un livre avec liste des épisodes où il est mentionné, tags Calibre associés (dates d'émission, coups de coeur), statut de lecture Calibre (📚 dans bibliothèque, ✓ Lu / ◯ Non lu, note), delta des tags manquants dans Calibre, et copie en un clic
 - 🔗 **Navigation inter-pages** : Liens clickables depuis recherche simple/avancée vers pages détail
 - 🎯 **Liens depuis biblio validation** : Auteurs et titres clickables dans la page `/livres-auteurs`
 - 🔄 **Liens épisodes** : Navigation directe depuis un livre vers validation biblio avec épisode pré-sélectionné

--- a/docs/claude/memory/260220-0228-issue214-calibre-enrichment-livre-detail.md
+++ b/docs/claude/memory/260220-0228-issue214-calibre-enrichment-livre-detail.md
@@ -1,0 +1,161 @@
+# Issue #214 — LivreDetail: Statut Calibre & Tag Delta
+
+## Objectif
+
+Sur la page de détail d'un livre (`LivreDetail.vue`), afficher le statut de la bibliothèque Calibre :
+- Indicateur "Dans Calibre" (badge 📚)
+- Statut de lecture ("✓ Lu" / "◯ Non lu") + note si lu
+- Masquer l'icône Anna's Archive si le livre est déjà dans la bibliothèque
+- Mettre en évidence les tags lmelp_ attendus qui ne sont pas encore dans Calibre (tag delta, couleur orange)
+- Exclure le tag "guillaume" (virtual library) du delta display
+- Bouton "Copier les tags" inclut les "notable tags" (`babelio`, `lu`, `onkindle`) déjà dans Calibre
+
+## Architecture de la solution
+
+### 1. Backend — `src/back_office_lmelp/services/calibre_matching_service.py`
+
+Extension de `enrich_palmares_item()` pour ajouter `calibre_current_tags` :
+
+```python
+def enrich_palmares_item(self, item, calibre_index):
+    calibre_book = calibre_index.get(norm_title)
+    if calibre_book:
+        item["calibre_in_library"] = True
+        item["calibre_read"] = calibre_book.get("read")
+        item["calibre_rating"] = calibre_book.get("rating") if calibre_book.get("read") else None
+        item["calibre_current_tags"] = calibre_book.get("tags")  # ← ajouté issue #214
+    else:
+        item["calibre_in_library"] = False
+        item["calibre_read"] = None
+        item["calibre_rating"] = None
+        item["calibre_current_tags"] = None  # ← ajouté issue #214
+```
+
+### 2. Backend — `src/back_office_lmelp/app.py`
+
+Appel dans `get_livre_detail()` après récupération de `livre_data` :
+
+```python
+# Issue #214: Enrich with Calibre library status
+try:
+    calibre_index = calibre_matching_service.get_calibre_index()
+    calibre_matching_service.enrich_palmares_item(livre_data, calibre_index)
+except Exception:
+    livre_data["calibre_in_library"] = False
+    livre_data["calibre_read"] = None
+    livre_data["calibre_rating"] = None
+    livre_data["calibre_current_tags"] = None
+```
+
+### 3. Frontend — `frontend/src/views/LivreDetail.vue`
+
+**Template — Anna's Archive conditionnel :**
+```html
+<a v-if="!livre.calibre_in_library" ...>  ← masqué si dans Calibre
+```
+
+**Template — Section statut Calibre :**
+```html
+<span v-if="livre.calibre_in_library" data-test="calibre-in-library">
+  <span>📚</span>
+  <span :class="livre.calibre_read ? 'read' : 'not-read'" data-test="calibre-read-badge">
+    {{ livre.calibre_read ? '✓ Lu' : '◯ Non lu' }}
+  </span>
+  <span v-if="livre.calibre_read && livre.calibre_rating != null" data-test="calibre-rating">
+    {{ livre.calibre_rating }}/10
+  </span>
+</span>
+```
+
+**Template — Tags avec delta :**
+```html
+<span
+  v-for="tag in displayedCalibreTags"
+  :class="['tag-badge', isTagMissingFromCalibre(tag) ? 'tag-missing' : 'tag-present']"
+  :data-test="isTagMissingFromCalibre(tag) ? 'tag-missing' : 'tag-badge'"
+>{{ tag }}</span>
+```
+
+**Computed `displayedCalibreTags` :**
+```javascript
+displayedCalibreTags() {
+  if (!this.livre?.calibre_tags) return [];
+  if (!this.livre.calibre_in_library) return this.livre.calibre_tags;
+  // Quand dans Calibre, masquer "guillaume" (virtual library tag) du delta
+  return this.livre.calibre_tags.filter((t) => t.startsWith('lmelp_'));
+},
+```
+
+**Méthode `isTagMissingFromCalibre(tag)` :**
+```javascript
+isTagMissingFromCalibre(tag) {
+  if (!this.livre?.calibre_in_library) return false;
+  if (!this.livre?.calibre_current_tags) return false;
+  return !this.livre.calibre_current_tags.includes(tag);
+},
+```
+
+**Méthode `copyTags()` — inclusion des notable tags :**
+```javascript
+async copyTags() {
+  const NOTABLE_TAGS = ['babelio', 'lu', 'onkindle'];
+  let tagsToCopy = [...this.livre.calibre_tags];
+
+  if (this.livre.calibre_in_library && this.livre.calibre_current_tags) {
+    const notablePresent = NOTABLE_TAGS.filter((t) => this.livre.calibre_current_tags.includes(t));
+    for (const notable of notablePresent) {
+      if (!tagsToCopy.includes(notable)) {
+        tagsToCopy.push(notable);
+      }
+    }
+  }
+  await navigator.clipboard.writeText(tagsToCopy.join(', '));
+}
+```
+
+## Tests écrits
+
+### Backend (`tests/test_livre_detail_calibre_enrichment.py`)
+- `test_livre_detail_includes_calibre_in_library_true`
+- `test_livre_detail_includes_calibre_in_library_false`
+- `test_livre_detail_includes_calibre_read_and_rating`
+- `test_livre_detail_includes_calibre_current_tags`
+- `test_livre_detail_calibre_unavailable_fallback`
+- `test_livre_detail_enrich_called_with_calibre_index`
+
+### Frontend (`frontend/src/views/__tests__/LivreDetailCalibre.spec.js`)
+- Shows / hides Calibre in-library badge
+- Shows / hides Anna's Archive icon based on `calibre_in_library`
+- Shows "Lu" / "Non lu" badge + rating
+- Tag delta highlighting (orange = missing, purple = present)
+- "guillaume" tag excluded from delta
+- `copyTags()` includes notable tags (`babelio`, `lu`) already in Calibre
+- `copyTags()` excludes notable tags NOT in Calibre
+- `copyTags()` works normally when not in Calibre
+
+## Piège découvert (Bug post-implémentation initiale)
+
+**Symptôme** : Bouton "Copier les tags" ne copiait pas `babelio`, `lu`, `onkindle` déjà dans Calibre.
+
+**Cause** : `copyTags()` ne copiait que `this.livre.calibre_tags` (tags MongoDB attendus), sans inclure les tags "notables" déjà présents dans Calibre (`calibre_current_tags`).
+
+**Fix** : Ajout de la logique d'union avec les `NOTABLE_TAGS` intersectés avec `calibre_current_tags`.
+
+**Note** : `NOTABLE_TAGS = ("babelio", "lu", "onkindle")` était déjà défini dans `calibre_matching_service.py` pour `get_corrections()` — même logique répliquée côté frontend.
+
+## CSS ajouté
+
+- `.calibre-status-section` — flex container pour badges
+- `.calibre-read-badge.read` — fond vert clair, texte vert
+- `.calibre-read-badge.not-read` — fond gris, texte gris
+- `.calibre-rating` — fond bleu clair, texte bleu
+- `.tag-missing` — fond orange clair, bordure dashed orange (tag attendu manquant dans Calibre)
+- `.tag-present` — fond violet clair (tag attendu présent dans Calibre, remplace `.tag-badge`)
+
+## Fallback gracieux
+
+Si Calibre est indisponible (exception dans `get_calibre_index`), le endpoint retourne quand même 200 avec :
+- `calibre_in_library = False`
+- `calibre_read = None`
+- `calibre_rating = None`
+- `calibre_current_tags = None`

--- a/docs/user/detail-pages.md
+++ b/docs/user/detail-pages.md
@@ -85,7 +85,9 @@ Dans la page **Livres et Auteurs** (`/livres-auteurs`), les auteurs et titres va
 │  [📘] [A]  📖 L'Étranger                                     │
 │  Babelio  Anna's ✍️ Auteur : Albert Camus                  │
 │         🏢 Éditeur : Gallimard                               │
-│         📅 2 émissions  lmelp_240324 lmelp_arnaud_viviant 📋│
+│         📅 2 émissions  📚 ✓ Lu  8/10                       │
+│         lmelp_240324 lmelp_arnaud_viviant 📋                │
+│         (tags orange = manquants dans Calibre)               │
 └─────────────────────────────────────────────────────────────┘
 
 ┌─────────────────────────────────────────────────────────────┐
@@ -120,15 +122,20 @@ Dans la page **Livres et Auteurs** (`/livres-auteurs`), les auteurs et titres va
 - **Titre du livre** : Affiché en haut de page
 - **Liens externes** : Icônes 80x80px cliquables vers les services externes
   - **Babelio** : Fiche du livre sur Babelio.com (si disponible)
-  - **Anna's Archive** : Recherche du livre sur Anna's Archive (toujours disponible)
+  - **Anna's Archive** : Recherche du livre sur Anna's Archive — **masqué** si le livre est dans Calibre (inutile si déjà possédé)
 - **Auteur** : Nom de l'auteur (clickable)
 - **Éditeur** : Maison d'édition
 - **Nombre d'émissions** : Total des mentions dans les émissions
-- **Tags Calibre** : Tags calculés dynamiquement, affichés comme badges violets en police monospace à côté du compteur d'émissions. Trois types de tags :
+- **Statut Calibre** : Affiché à côté du compteur d'émissions si Calibre est configuré :
+  - **📚** : Indicateur "Dans la bibliothèque Calibre"
+  - **✓ Lu** (vert) ou **◯ Non lu** (gris) : Statut de lecture
+  - **N/10** (bleu) : Note Calibre si le livre a été lu et noté
+- **Tags Calibre** : Tags calculés dynamiquement à côté du compteur d'émissions. Trois types de tags :
     - `lmelp_yyMMdd` : un tag par émission où le livre a été discuté (date au format année-mois-jour sur 2 chiffres)
     - `lmelp_prenom_nom` : un tag par critique ayant donné un coup de cœur au livre
-    - Tag de bibliothèque virtuelle (ex: `guillaume`) : affiché en premier dès que des tags `lmelp_*` existent, que le livre soit ou non dans Calibre. L'utilisateur dispose ainsi de tous les tags prêts à copier-coller dans Calibre
-    - Un bouton 📋 permet de copier tous les tags (séparés par des virgules) dans le presse-papier. Le bouton affiche ✓ pendant 2 secondes après la copie
+    - Tag de bibliothèque virtuelle (ex: `guillaume`) : affiché en premier dès que des tags `lmelp_*` existent, que le livre soit ou non dans Calibre. **Masqué du delta** quand le livre est dans Calibre (non informatif)
+    - **Couleur des tags** : Si le livre est dans Calibre, les tags `lmelp_` manquants dans Calibre apparaissent en **orange avec bordure pointillée** ; les tags déjà présents en **violet** (normal)
+    - Un bouton 📋 permet de copier tous les tags (séparés par des virgules) dans le presse-papier. Quand le livre est dans Calibre, le bouton inclut aussi les tags "notables" (`babelio`, `lu`, `onkindle`) déjà présents dans Calibre. Le bouton affiche ✓ pendant 2 secondes après la copie
     - Si aucun tag n'est disponible, cette section n'est pas affichée
 - **Liste des émissions** : Toutes les émissions mentionnant ce livre
   - Date de l'émission (clickable vers la page émission)
@@ -144,10 +151,10 @@ Dans la page **Livres et Auteurs** (`/livres-auteurs`), les auteurs et titres va
 ### Actions disponibles
 
 - **Cliquer sur l'icône Babelio** : Ouverture de la fiche livre sur Babelio.com (nouvel onglet)
-- **Cliquer sur l'icône Anna's Archive** : Recherche du livre (titre + auteur) sur Anna's Archive (nouvel onglet)
+- **Cliquer sur l'icône Anna's Archive** : Recherche du livre (titre + auteur) sur Anna's Archive (nouvel onglet) — disponible uniquement si le livre n'est pas dans Calibre
 - **Ré-extraire depuis Babelio** : Bouton orange visible uniquement si le livre possède une URL Babelio. Scrape les données fraîches (titre, auteur, éditeur) depuis Babelio et les applique automatiquement si des différences sont détectées. Une notification toast confirme le résultat (succès en vert, données identiques en bleu, erreur en rouge). L'éditeur mis à jour est stocké via la collection `editeurs` dédiée
 - **Cliquer sur l'auteur** : Accès à la page détail de cet auteur
-- **Copier les tags Calibre** : Bouton 📋 copie tous les tags séparés par des virgules dans le presse-papier
+- **Copier les tags Calibre** : Bouton 📋 copie tous les tags séparés par des virgules dans le presse-papier. Quand le livre est dans Calibre, inclut les tags "notables" (`babelio`, `lu`, `onkindle`) déjà présents dans Calibre
 - **Cliquer sur une émission** : Navigation vers la page émission correspondante
 - **Cliquer sur un critique** : Accès à la page détail du critique
 - **Retour au Dashboard** : Bouton "🏠 Accueil" en haut de page

--- a/frontend/src/views/__tests__/LivreDetailCalibre.spec.js
+++ b/frontend/src/views/__tests__/LivreDetailCalibre.spec.js
@@ -1,0 +1,348 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { mount } from '@vue/test-utils';
+import LivreDetail from '../LivreDetail.vue';
+import axios from 'axios';
+
+// Mock axios
+vi.mock('axios', () => ({
+  default: {
+    get: vi.fn(),
+    post: vi.fn(),
+  },
+}));
+
+// Mock router
+const mockRoute = {
+  params: { id: '507f1f77bcf86cd799439011' }, // pragma: allowlist secret
+};
+
+const mockRouter = {
+  back: vi.fn(),
+};
+
+describe('LivreDetail - Calibre enrichment (Issue #214)', () => {
+  beforeEach(() => {
+    vi.resetAllMocks();
+  });
+
+  function mountComponent() {
+    return mount(LivreDetail, {
+      global: {
+        mocks: {
+          $route: mockRoute,
+          $router: mockRouter,
+        },
+        stubs: {
+          'router-link': {
+            template: '<a><slot /></a>',
+            props: ['to'],
+          },
+          Navigation: { template: '<div />' },
+        },
+      },
+    });
+  }
+
+  function mockAxiosWithLivre(livreData) {
+    axios.get.mockImplementation((url) => {
+      if (url.includes('/api/livre/')) {
+        return Promise.resolve({ data: livreData });
+      }
+      if (url.includes('/api/avis/by-livre/')) {
+        return Promise.resolve({ data: { avis: [] } });
+      }
+      if (url.includes('/api/config/annas-archive-url')) {
+        return Promise.resolve({ data: { url: 'https://fr.annas-archive.org' } });
+      }
+      return Promise.reject(new Error(`Unexpected URL: ${url}`));
+    });
+  }
+
+  const baseLivreData = {
+    livre_id: '507f1f77bcf86cd799439011',
+    titre: 'L\'Adversaire',
+    auteur_id: '507f1f77bcf86cd799439012',
+    auteur_nom: 'Emmanuel Carrère',
+    editeur: 'Gallimard',
+    note_moyenne: 7.5,
+    nombre_emissions: 1,
+    emissions: [],
+    calibre_tags: ['lmelp_240324'],
+    calibre_in_library: false,
+    calibre_read: null,
+    calibre_rating: null,
+    calibre_current_tags: null,
+  };
+
+  it('shows Calibre in-library badge when book is in Calibre', async () => {
+    mockAxiosWithLivre({
+      ...baseLivreData,
+      calibre_in_library: true,
+      calibre_read: false,
+      calibre_rating: null,
+      calibre_current_tags: [],
+    });
+
+    const wrapper = mountComponent();
+    await wrapper.vm.$nextTick();
+    await new Promise((resolve) => setTimeout(resolve, 50));
+
+    expect(wrapper.find('[data-test="calibre-in-library"]').exists()).toBe(true);
+  });
+
+  it('hides Calibre in-library badge when book is not in Calibre', async () => {
+    mockAxiosWithLivre({
+      ...baseLivreData,
+      calibre_in_library: false,
+    });
+
+    const wrapper = mountComponent();
+    await wrapper.vm.$nextTick();
+    await new Promise((resolve) => setTimeout(resolve, 50));
+
+    expect(wrapper.find('[data-test="calibre-in-library"]').exists()).toBe(false);
+  });
+
+  it('hides Anna\'s Archive icon when book is in Calibre library', async () => {
+    mockAxiosWithLivre({
+      ...baseLivreData,
+      calibre_in_library: true,
+      calibre_read: false,
+      calibre_rating: null,
+      calibre_current_tags: [],
+    });
+
+    const wrapper = mountComponent();
+    await wrapper.vm.$nextTick();
+    await new Promise((resolve) => setTimeout(resolve, 50));
+
+    expect(wrapper.find('[data-test="annas-archive-link"]').exists()).toBe(false);
+  });
+
+  it('shows Anna\'s Archive icon when book is not in Calibre library', async () => {
+    mockAxiosWithLivre({
+      ...baseLivreData,
+      calibre_in_library: false,
+    });
+
+    const wrapper = mountComponent();
+    await wrapper.vm.$nextTick();
+    await new Promise((resolve) => setTimeout(resolve, 50));
+
+    expect(wrapper.find('[data-test="annas-archive-link"]').exists()).toBe(true);
+  });
+
+  it('shows "Lu" badge with rating when book is read and has rating', async () => {
+    mockAxiosWithLivre({
+      ...baseLivreData,
+      calibre_in_library: true,
+      calibre_read: true,
+      calibre_rating: 8,
+      calibre_current_tags: ['lmelp_240324'],
+    });
+
+    const wrapper = mountComponent();
+    await wrapper.vm.$nextTick();
+    await new Promise((resolve) => setTimeout(resolve, 50));
+
+    expect(wrapper.find('[data-test="calibre-read-badge"]').exists()).toBe(true);
+    expect(wrapper.find('[data-test="calibre-read-badge"]').text()).toContain('Lu');
+    expect(wrapper.find('[data-test="calibre-rating"]').exists()).toBe(true);
+    expect(wrapper.find('[data-test="calibre-rating"]').text()).toContain('8');
+  });
+
+  it('shows "Non lu" badge when book is in Calibre but not read', async () => {
+    mockAxiosWithLivre({
+      ...baseLivreData,
+      calibre_in_library: true,
+      calibre_read: false,
+      calibre_rating: null,
+      calibre_current_tags: [],
+    });
+
+    const wrapper = mountComponent();
+    await wrapper.vm.$nextTick();
+    await new Promise((resolve) => setTimeout(resolve, 50));
+
+    expect(wrapper.find('[data-test="calibre-read-badge"]').exists()).toBe(true);
+    const badgeText = wrapper.find('[data-test="calibre-read-badge"]').text();
+    expect(badgeText).not.toContain('Lu');
+  });
+
+  it('highlights tags missing from Calibre (tag delta) in different style', async () => {
+    mockAxiosWithLivre({
+      ...baseLivreData,
+      calibre_tags: ['lmelp_240101', 'lmelp_240324', 'lmelp_arnaud_viviant'],
+      calibre_in_library: true,
+      calibre_read: true,
+      calibre_rating: 7,
+      // Only lmelp_240101 is in Calibre currently
+      calibre_current_tags: ['lmelp_240101', 'babelio'],
+    });
+
+    const wrapper = mountComponent();
+    await wrapper.vm.$nextTick();
+    await new Promise((resolve) => setTimeout(resolve, 50));
+
+    // Tags missing from Calibre should have a distinct marker
+    const missingTags = wrapper.findAll('[data-test="tag-missing"]');
+    expect(missingTags.length).toBeGreaterThan(0);
+
+    // lmelp_240324 and lmelp_arnaud_viviant should be marked as missing
+    const missingTexts = missingTags.map((el) => el.text());
+    expect(missingTexts).toContain('lmelp_240324');
+    expect(missingTexts).toContain('lmelp_arnaud_viviant');
+  });
+
+  it('shows no tag delta when book is not in Calibre', async () => {
+    mockAxiosWithLivre({
+      ...baseLivreData,
+      calibre_tags: ['lmelp_240324'],
+      calibre_in_library: false,
+      calibre_current_tags: null,
+    });
+
+    const wrapper = mountComponent();
+    await wrapper.vm.$nextTick();
+    await new Promise((resolve) => setTimeout(resolve, 50));
+
+    expect(wrapper.find('[data-test="tag-missing"]').exists()).toBe(false);
+  });
+
+  it('shows no tag delta when all tags are present in Calibre', async () => {
+    mockAxiosWithLivre({
+      ...baseLivreData,
+      calibre_tags: ['lmelp_240324'],
+      calibre_in_library: true,
+      calibre_read: false,
+      calibre_rating: null,
+      calibre_current_tags: ['lmelp_240324', 'babelio'],
+    });
+
+    const wrapper = mountComponent();
+    await wrapper.vm.$nextTick();
+    await new Promise((resolve) => setTimeout(resolve, 50));
+
+    expect(wrapper.find('[data-test="tag-missing"]').exists()).toBe(false);
+  });
+
+  it('does not show guillaume in tag delta comparison', async () => {
+    // guillaume is the virtual library tag, it should be excluded from delta
+    mockAxiosWithLivre({
+      ...baseLivreData,
+      // calibre_tags includes "guillaume" as first tag (virtual library tag)
+      calibre_tags: ['guillaume', 'lmelp_240324'],
+      calibre_in_library: true,
+      calibre_read: false,
+      calibre_rating: null,
+      // guillaume is NOT in calibre_current_tags, but it should be ignored in delta
+      calibre_current_tags: ['lmelp_240324'],
+    });
+
+    const wrapper = mountComponent();
+    await wrapper.vm.$nextTick();
+    await new Promise((resolve) => setTimeout(resolve, 50));
+
+    // No tags should be missing (guillaume is excluded from delta)
+    expect(wrapper.find('[data-test="tag-missing"]').exists()).toBe(false);
+  });
+
+  it('copy button includes notable tags (babelio, lu, onkindle) already in Calibre', async () => {
+    // Real case: Calibre has babelio, guillaume, lmelp_210912, lu
+    // Copy should produce: guillaume, lmelp_210912, babelio, lu
+    // i.e. all calibre_tags + notable tags already in calibre_current_tags
+    const writeTextMock = vi.fn().mockResolvedValue(undefined);
+    Object.defineProperty(navigator, 'clipboard', {
+      value: { writeText: writeTextMock },
+      writable: true,
+    });
+
+    mockAxiosWithLivre({
+      ...baseLivreData,
+      calibre_tags: ['guillaume', 'lmelp_210912'],
+      calibre_in_library: true,
+      calibre_read: true,
+      calibre_rating: null,
+      // Current Calibre tags include notable tags: babelio, lu
+      calibre_current_tags: ['babelio', 'guillaume', 'lmelp_210912', 'lu'],
+    });
+
+    const wrapper = mountComponent();
+    await wrapper.vm.$nextTick();
+    await new Promise((resolve) => setTimeout(resolve, 50));
+
+    // Click copy button
+    await wrapper.find('[data-test="copy-tags-btn"]').trigger('click');
+    await wrapper.vm.$nextTick();
+
+    // The copied string should include babelio and lu (notable tags from Calibre)
+    expect(writeTextMock).toHaveBeenCalledOnce();
+    const copiedText = writeTextMock.mock.calls[0][0];
+    expect(copiedText).toContain('babelio');
+    expect(copiedText).toContain('lu');
+    expect(copiedText).toContain('lmelp_210912');
+    expect(copiedText).toContain('guillaume');
+  });
+
+  it('copy button does NOT include non-notable tags from Calibre (e.g. onkindle not present)', async () => {
+    // Only notable tags that are ALREADY in calibre_current_tags should be included
+    const writeTextMock = vi.fn().mockResolvedValue(undefined);
+    Object.defineProperty(navigator, 'clipboard', {
+      value: { writeText: writeTextMock },
+      writable: true,
+    });
+
+    mockAxiosWithLivre({
+      ...baseLivreData,
+      calibre_tags: ['guillaume', 'lmelp_240324'],
+      calibre_in_library: true,
+      calibre_read: false,
+      calibre_rating: null,
+      // Only babelio is in Calibre (not onkindle, not lu)
+      calibre_current_tags: ['babelio', 'guillaume', 'lmelp_240324'],
+    });
+
+    const wrapper = mountComponent();
+    await wrapper.vm.$nextTick();
+    await new Promise((resolve) => setTimeout(resolve, 50));
+
+    await wrapper.find('[data-test="copy-tags-btn"]').trigger('click');
+    await wrapper.vm.$nextTick();
+
+    expect(writeTextMock).toHaveBeenCalledOnce();
+    const copiedText = writeTextMock.mock.calls[0][0];
+    expect(copiedText).toContain('babelio');
+    expect(copiedText).not.toContain('onkindle'); // not in calibre_current_tags
+    expect(copiedText).not.toContain('lu');       // not in calibre_current_tags
+  });
+
+  it('copy button works normally (no notable tags added) when book is not in Calibre', async () => {
+    const writeTextMock = vi.fn().mockResolvedValue(undefined);
+    Object.defineProperty(navigator, 'clipboard', {
+      value: { writeText: writeTextMock },
+      writable: true,
+    });
+
+    mockAxiosWithLivre({
+      ...baseLivreData,
+      calibre_tags: ['guillaume', 'lmelp_240324'],
+      calibre_in_library: false,
+      calibre_current_tags: null,
+    });
+
+    const wrapper = mountComponent();
+    await wrapper.vm.$nextTick();
+    await new Promise((resolve) => setTimeout(resolve, 50));
+
+    await wrapper.find('[data-test="copy-tags-btn"]').trigger('click');
+    await wrapper.vm.$nextTick();
+
+    expect(writeTextMock).toHaveBeenCalledOnce();
+    const copiedText = writeTextMock.mock.calls[0][0];
+    expect(copiedText).toContain('guillaume');
+    expect(copiedText).toContain('lmelp_240324');
+    // No notable tags added since not in Calibre
+    expect(copiedText).not.toContain('babelio');
+    expect(copiedText).not.toContain('lu');
+  });
+});

--- a/src/back_office_lmelp/app.py
+++ b/src/back_office_lmelp/app.py
@@ -2248,6 +2248,16 @@ async def get_livre_detail(livre_id: str) -> dict[str, Any]:
         if settings.calibre_virtual_library_tag and livre_data.get("calibre_tags"):
             livre_data["calibre_tags"].insert(0, settings.calibre_virtual_library_tag)
 
+        # Issue #214: Enrich with Calibre library status (in_library, read, rating, current_tags)
+        try:
+            calibre_index = calibre_matching_service.get_calibre_index()
+            calibre_matching_service.enrich_palmares_item(livre_data, calibre_index)
+        except Exception:
+            livre_data["calibre_in_library"] = False
+            livre_data["calibre_read"] = None
+            livre_data["calibre_rating"] = None
+            livre_data["calibre_current_tags"] = None
+
         return livre_data
     except HTTPException:
         raise

--- a/src/back_office_lmelp/services/calibre_matching_service.py
+++ b/src/back_office_lmelp/services/calibre_matching_service.py
@@ -307,7 +307,7 @@ class CalibreMatchingService:
     ) -> None:
         """Enrichit un item du palmarès avec les données Calibre.
 
-        Ajoute calibre_in_library, calibre_read, calibre_rating.
+        Ajoute calibre_in_library, calibre_read, calibre_rating, calibre_current_tags.
         """
         norm_title = normalize_for_matching(item.get("titre", ""))
         calibre_book = calibre_index.get(norm_title)
@@ -318,10 +318,12 @@ class CalibreMatchingService:
             item["calibre_rating"] = (
                 calibre_book.get("rating") if calibre_book.get("read") else None
             )
+            item["calibre_current_tags"] = calibre_book.get("tags")
         else:
             item["calibre_in_library"] = False
             item["calibre_read"] = None
             item["calibre_rating"] = None
+            item["calibre_current_tags"] = None
 
     def get_corrections(self) -> dict[str, Any]:
         """Calcule les corrections à appliquer dans Calibre.

--- a/tests/test_livre_detail_calibre_enrichment.py
+++ b/tests/test_livre_detail_calibre_enrichment.py
@@ -1,0 +1,206 @@
+"""Tests for Calibre enrichment on livre detail page (Issue #214).
+
+Tests that GET /api/livre/{id} includes:
+- calibre_in_library: whether the book is in the Calibre library
+- calibre_read: whether the book has been read
+- calibre_rating: the Calibre rating if available
+- calibre_current_tags: the actual tags from Calibre (for delta display)
+"""
+
+from unittest.mock import patch
+
+import pytest
+from bson import ObjectId
+from fastapi.testclient import TestClient
+
+from back_office_lmelp.app import app
+
+
+@pytest.fixture
+def client():
+    """Create a test client."""
+    return TestClient(app)
+
+
+def make_livre_data(livre_id: str, titre: str = "Test Book") -> dict:
+    """Build a minimal livre_data dict."""
+    return {
+        "livre_id": livre_id,
+        "titre": titre,
+        "auteur_id": str(ObjectId()),
+        "auteur_nom": "Test Author",
+        "editeur": "Test Publisher",
+        "url_babelio": None,
+        "note_moyenne": None,
+        "nombre_emissions": 0,
+        "emissions": [],
+        "calibre_tags": ["lmelp_240324"],
+    }
+
+
+class TestLivreDetailCalibreEnrichment:
+    """Tests pour l'enrichissement Calibre dans GET /api/livre/{livre_id}."""
+
+    @patch("back_office_lmelp.app.calibre_matching_service")
+    @patch("back_office_lmelp.app.mongodb_service")
+    def test_livre_detail_includes_calibre_in_library_true(
+        self, mock_mongodb_service, mock_calibre_service, client
+    ):
+        """Test that calibre_in_library=True when book is in Calibre index."""
+        livre_id = str(ObjectId())
+        mock_mongodb_service.get_livre_with_episodes.return_value = make_livre_data(
+            livre_id, titre="L'Adversaire"
+        )
+
+        # Simulate calibre enrich_palmares_item setting calibre_in_library=True
+        def mock_enrich(item, calibre_index):
+            item["calibre_in_library"] = True
+            item["calibre_read"] = False
+            item["calibre_rating"] = None
+            item["calibre_current_tags"] = ["lmelp_240324"]
+
+        mock_calibre_service.get_calibre_index.return_value = {}
+        mock_calibre_service.enrich_palmares_item.side_effect = mock_enrich
+
+        response = client.get(f"/api/livre/{livre_id}")
+
+        assert response.status_code == 200
+        data = response.json()
+        assert data["calibre_in_library"] is True
+
+    @patch("back_office_lmelp.app.calibre_matching_service")
+    @patch("back_office_lmelp.app.mongodb_service")
+    def test_livre_detail_includes_calibre_in_library_false(
+        self, mock_mongodb_service, mock_calibre_service, client
+    ):
+        """Test that calibre_in_library=False when book is NOT in Calibre index."""
+        livre_id = str(ObjectId())
+        mock_mongodb_service.get_livre_with_episodes.return_value = make_livre_data(
+            livre_id, titre="Livre Inconnu"
+        )
+
+        def mock_enrich(item, calibre_index):
+            item["calibre_in_library"] = False
+            item["calibre_read"] = None
+            item["calibre_rating"] = None
+            item["calibre_current_tags"] = None
+
+        mock_calibre_service.get_calibre_index.return_value = {}
+        mock_calibre_service.enrich_palmares_item.side_effect = mock_enrich
+
+        response = client.get(f"/api/livre/{livre_id}")
+
+        assert response.status_code == 200
+        data = response.json()
+        assert data["calibre_in_library"] is False
+
+    @patch("back_office_lmelp.app.calibre_matching_service")
+    @patch("back_office_lmelp.app.mongodb_service")
+    def test_livre_detail_includes_calibre_read_and_rating(
+        self, mock_mongodb_service, mock_calibre_service, client
+    ):
+        """Test that calibre_read=True and calibre_rating are included when book is read."""
+        livre_id = str(ObjectId())
+        mock_mongodb_service.get_livre_with_episodes.return_value = make_livre_data(
+            livre_id, titre="La Deuxième Vie"
+        )
+
+        def mock_enrich(item, calibre_index):
+            item["calibre_in_library"] = True
+            item["calibre_read"] = True
+            item["calibre_rating"] = 8
+            item["calibre_current_tags"] = ["lmelp_240324"]
+
+        mock_calibre_service.get_calibre_index.return_value = {}
+        mock_calibre_service.enrich_palmares_item.side_effect = mock_enrich
+
+        response = client.get(f"/api/livre/{livre_id}")
+
+        assert response.status_code == 200
+        data = response.json()
+        assert data["calibre_in_library"] is True
+        assert data["calibre_read"] is True
+        assert data["calibre_rating"] == 8
+
+    @patch("back_office_lmelp.app.calibre_matching_service")
+    @patch("back_office_lmelp.app.mongodb_service")
+    def test_livre_detail_includes_calibre_current_tags(
+        self, mock_mongodb_service, mock_calibre_service, client
+    ):
+        """Test that calibre_current_tags from Calibre are returned for tag delta."""
+        livre_id = str(ObjectId())
+        mock_mongodb_service.get_livre_with_episodes.return_value = {
+            **make_livre_data(livre_id, titre="Test Book"),
+            "calibre_tags": ["lmelp_240101", "lmelp_240324", "lmelp_arnaud_viviant"],
+        }
+
+        def mock_enrich(item, calibre_index):
+            item["calibre_in_library"] = True
+            item["calibre_read"] = True
+            item["calibre_rating"] = 7
+            # Only lmelp_240101 is already in Calibre
+            item["calibre_current_tags"] = ["lmelp_240101", "babelio"]
+
+        mock_calibre_service.get_calibre_index.return_value = {}
+        mock_calibre_service.enrich_palmares_item.side_effect = mock_enrich
+
+        response = client.get(f"/api/livre/{livre_id}")
+
+        assert response.status_code == 200
+        data = response.json()
+        assert data["calibre_current_tags"] == ["lmelp_240101", "babelio"]
+
+    @patch("back_office_lmelp.app.calibre_matching_service")
+    @patch("back_office_lmelp.app.mongodb_service")
+    def test_livre_detail_calibre_unavailable_fallback(
+        self, mock_mongodb_service, mock_calibre_service, client
+    ):
+        """Test graceful fallback when Calibre is unavailable."""
+        livre_id = str(ObjectId())
+        mock_mongodb_service.get_livre_with_episodes.return_value = make_livre_data(
+            livre_id
+        )
+
+        # Simulate Calibre unavailable: get_calibre_index raises
+        mock_calibre_service.get_calibre_index.side_effect = RuntimeError(
+            "Calibre non disponible"
+        )
+
+        response = client.get(f"/api/livre/{livre_id}")
+
+        # Should still return 200 with livre data, just no calibre enrichment
+        assert response.status_code == 200
+        data = response.json()
+        assert data["calibre_in_library"] is False
+        assert data["calibre_read"] is None
+        assert data["calibre_rating"] is None
+        assert data["calibre_current_tags"] is None
+
+    @patch("back_office_lmelp.app.calibre_matching_service")
+    @patch("back_office_lmelp.app.mongodb_service")
+    def test_livre_detail_enrich_called_with_calibre_index(
+        self, mock_mongodb_service, mock_calibre_service, client
+    ):
+        """Test that enrich_palmares_item is called with the calibre index."""
+        livre_id = str(ObjectId())
+        mock_mongodb_service.get_livre_with_episodes.return_value = make_livre_data(
+            livre_id
+        )
+
+        calibre_index = {"test book": {"id": 1, "read": False, "rating": None}}
+        mock_calibre_service.get_calibre_index.return_value = calibre_index
+
+        def mock_enrich(item, index):
+            item["calibre_in_library"] = False
+            item["calibre_read"] = None
+            item["calibre_rating"] = None
+            item["calibre_current_tags"] = None
+
+        mock_calibre_service.enrich_palmares_item.side_effect = mock_enrich
+
+        response = client.get(f"/api/livre/{livre_id}")
+
+        assert response.status_code == 200
+        mock_calibre_service.enrich_palmares_item.assert_called_once()
+        call_args = mock_calibre_service.enrich_palmares_item.call_args
+        assert call_args[0][1] == calibre_index


### PR DESCRIPTION
## Summary

- **Statut Calibre sur la page livre** : badge 📚 + indicateur Lu/Non lu + note (N/10) affichés à côté du compteur d'émissions
- **Anna's Archive masqué** quand le livre est déjà dans la bibliothèque Calibre (inutile si déjà possédé)
- **Tag delta** : les tags `lmelp_` attendus mais absents dans Calibre s'affichent en orange avec bordure pointillée ; le tag de bibliothèque virtuelle (`guillaume`) est masqué du delta (non informatif)
- **Bouton Copier les tags** : inclut désormais les tags "notables" (`babelio`, `lu`, `onkindle`) déjà présents dans Calibre pour préserver lors du réimport

## Détails techniques

### Backend
- `CalibreMatchingService.enrich_palmares_item()` : ajout de `calibre_current_tags` (liste des tags Calibre actuels du livre)
- `GET /api/livre/{id}` : enrichissement avec statut Calibre complet + fallback gracieux si Calibre indisponible

### Frontend (`LivreDetail.vue`)
- Computed `displayedCalibreTags` : filtre le tag virtuel (`guillaume`) quand le livre est dans Calibre
- Méthode `isTagMissingFromCalibre(tag)` : compare tags attendus vs tags Calibre actuels
- Méthode `copyTags()` : union avec les notable tags déjà dans Calibre

### Tests
- 6 tests backend (`tests/test_livre_detail_calibre_enrichment.py`)
- 13 tests frontend (`frontend/src/views/__tests__/LivreDetailCalibre.spec.js`)

## Test plan

- [ ] Vérifier qu'un livre dans Calibre affiche le badge 📚 + statut lecture
- [ ] Vérifier que l'icône Anna's Archive est masquée pour un livre dans Calibre
- [ ] Vérifier les tags orange (manquants dans Calibre) vs violets (présents)
- [ ] Vérifier que le bouton Copier les tags inclut `babelio`/`lu` si déjà dans Calibre
- [ ] Vérifier qu'un livre absent de Calibre affiche Anna's Archive normalement

🤖 Generated with [Claude Code](https://claude.com/claude-code)