### PR TITLE
Add refresh button and cache notice to OnKindle page (Issue #249)

### DIFF
--- a/docs/claude/memory/260613-1235-issue249-onkindle-cache-refresh.md
+++ b/docs/claude/memory/260613-1235-issue249-onkindle-cache-refresh.md
@@ -1,0 +1,76 @@
+# Issue #249 - OnKindle : bouton Actualiser + message cache 5 min
+
+## Contexte
+
+Les données de la page OnKindle proviennent du cache in-memory de `CalibreMatchingService`
+(`_cache_ttl = 300s`). Quand l'utilisateur modifie des tags `onkindle` dans Calibre, les
+changements n'apparaissent pas immédiatement dans l'app (jusqu'à 5 minutes de délai).
+
+L'utilisateur avait constaté un écart de 3 livres entre l'app et le Kindle réel — en réalité
+les tags avaient été supprimés dans Calibre mais le cache de l'app était encore valide.
+
+## Cause racine
+
+`CalibreMatchingService._get_data()` met en cache les données Calibre pendant 5 minutes.
+`get_onkindle_books()` consomme ce cache via `_get_data()`. Le endpoint d'invalidation
+`POST /api/calibre/cache/invalidate` existait déjà (`app.py:890`) mais n'était pas exposé
+à l'utilisateur depuis la page OnKindle.
+
+## Fix implémenté
+
+Fichier modifié : `frontend/src/views/OnKindle.vue`
+
+### 1. Message informatif dans le header
+
+Ajout d'un span `"Mise en cache 5 min"` à côté du compteur de livres.
+CSS : classe `.cache-info` (texte gris italique, `margin-left: auto` pour pousser à droite).
+
+### 2. Bouton Actualiser
+
+- Attribut `data-test="refresh-button"` pour les tests
+- Désactivé (`:disabled="refreshing"`) pendant l'opération
+- Texte dynamique : `"Actualiser"` → `"Actualisation…"`
+
+### 3. Méthode `refreshData()`
+
+```javascript
+async refreshData() {
+  this.refreshing = true;
+  this.error = null;
+  try {
+    await axios.post('/api/calibre/cache/invalidate');
+    await this.loadOnKindleBooks();
+  } catch (err) {
+    this.error = err.message || 'Erreur lors de l\'actualisation';
+  } finally {
+    this.refreshing = false;
+  }
+},
+```
+
+Séquence : POST invalidate → GET onkindle → affichage rafraîchi.
+
+## Tests ajoutés
+
+Fichier : `frontend/src/views/__tests__/OnKindle.spec.js`
+Section : `describe('Cache refresh (Issue #249)', ...)`
+
+5 tests TDD (RED → GREEN) :
+1. Affiche un message mentionnant "5 min"
+2. Affiche un bouton `[data-test="refresh-button"]`
+3. Clic bouton → appelle `POST /api/calibre/cache/invalidate` puis `GET /api/calibre/onkindle`
+4. Bouton désactivé pendant le refresh (`disabled` attribute présent)
+5. Affiche une erreur si l'invalidation échoue
+
+## Architecture existante réutilisée
+
+- `POST /api/calibre/cache/invalidate` (`app.py:890`) : endpoint déjà présent, appelé directement
+- `loadOnKindleBooks()` : méthode existante réutilisée après invalidation
+- `data.error` + `[data-test="error"]` : pattern d'affichage d'erreur déjà en place
+
+## Leçon
+
+Le cache 5 min de `CalibreMatchingService` est intentionnel (performance). Pour les pages
+qui lisent ce cache, toujours exposer un bouton de refresh qui appelle
+`POST /api/calibre/cache/invalidate`. Le endpoint d'invalidation est générique et invalide
+tout le cache matching (utile pour OnKindle mais aussi pour les corrections Calibre).

--- a/docs/user/calibre-integration.md
+++ b/docs/user/calibre-integration.md
@@ -231,6 +231,7 @@ La page **OnKindle** (`/onkindle`) affiche tous les livres Calibre portant le ta
 - **Enrichissement MongoDB** : Les livres Calibre matchés avec MongoDB affichent leur note LMELP et leur lien Babelio.
 - **Score Reco** : Calculé par l'algorithme de collaborative filtering SVD (voir page Recommandations). Le score se charge en arrière-plan (~10 secondes) ; la table s'affiche immédiatement avec `-` dans la colonne Reco pendant le calcul.
 - **Dégradation gracieuse** : Si Calibre n'est pas disponible, un message explicite est affiché. Si l'API de recommandations échoue, `-` est affiché pour tous les scores sans bloquer la page.
+- **Mise en cache 5 min** : Les données Calibre sont mises en cache pendant 5 minutes. Si vous venez de modifier un tag `onkindle` dans Calibre, cliquez sur **"Actualiser"** pour invalider le cache et voir immédiatement les changements.
 
 **Correspondance Calibre-MongoDB** :
 

--- a/frontend/src/views/OnKindle.vue
+++ b/frontend/src/views/OnKindle.vue
@@ -27,6 +27,13 @@
       <div class="onkindle-header">
         <h1>Livres OnKindle</h1>
         <span class="total-count">{{ books.length }} livre{{ books.length > 1 ? 's' : '' }}</span>
+        <span class="cache-info">Mise en cache 5 min</span>
+        <button
+          class="refresh-btn"
+          data-test="refresh-button"
+          :disabled="refreshing"
+          @click="refreshData"
+        >{{ refreshing ? 'Actualisation…' : 'Actualiser' }}</button>
       </div>
 
       <!-- Tableau -->
@@ -179,6 +186,7 @@ export default {
       recommendationsLoading: false,
       sortKey: 'score',
       sortDir: 'desc',
+      refreshing: false,
     };
   },
 
@@ -258,6 +266,19 @@ export default {
       await this.$router.replace({
         query: { sort: this.sortKey, dir: this.sortDir },
       });
+    },
+
+    async refreshData() {
+      this.refreshing = true;
+      this.error = null;
+      try {
+        await axios.post('/api/calibre/cache/invalidate');
+        await this.loadOnKindleBooks();
+      } catch (err) {
+        this.error = err.message || 'Erreur lors de l\'actualisation';
+      } finally {
+        this.refreshing = false;
+      }
     },
 
     async loadOnKindleBooks() {
@@ -376,6 +397,33 @@ export default {
   border-radius: 20px;
   font-size: 0.9rem;
   font-weight: 500;
+}
+
+.cache-info {
+  font-size: 0.8rem;
+  color: #999;
+  font-style: italic;
+  margin-left: auto;
+}
+
+.refresh-btn {
+  padding: 0.35rem 0.9rem;
+  font-size: 0.85rem;
+  background: #f0f2ff;
+  color: #667eea;
+  border: 1px solid #c5cdf5;
+  border-radius: 8px;
+  cursor: pointer;
+  transition: background 0.15s;
+}
+
+.refresh-btn:hover:not(:disabled) {
+  background: #e0e4ff;
+}
+
+.refresh-btn:disabled {
+  opacity: 0.6;
+  cursor: not-allowed;
 }
 
 /* Sort headers */

--- a/frontend/src/views/__tests__/OnKindle.spec.js
+++ b/frontend/src/views/__tests__/OnKindle.spec.js
@@ -607,4 +607,59 @@ describe('OnKindle.vue', () => {
       expect(wrapper.vm.sortDir).toBe('asc');
     });
   });
+
+  describe('Cache refresh (Issue #249)', () => {
+    it('shows a cache info message mentioning 5-minute caching', async () => {
+      await mountWithData();
+
+      expect(wrapper.text()).toMatch(/5.min/i);
+    });
+
+    it('shows a refresh button', async () => {
+      await mountWithData();
+
+      const refreshBtn = wrapper.find('[data-test="refresh-button"]');
+      expect(refreshBtn.exists()).toBe(true);
+    });
+
+    it('clicking refresh button calls cache invalidate then reloads onkindle data', async () => {
+      await mountWithData();
+
+      // Setup: invalidate returns 200, then new onkindle call
+      axios.post.mockResolvedValueOnce({ data: { message: 'Cache invalidated' } });
+      axios.get.mockResolvedValueOnce({ data: mockOnKindleData });
+
+      const refreshBtn = wrapper.find('[data-test="refresh-button"]');
+      await refreshBtn.trigger('click');
+      await flushPromises();
+
+      expect(axios.post).toHaveBeenCalledWith('/api/calibre/cache/invalidate');
+      expect(axios.get).toHaveBeenCalledWith('/api/calibre/onkindle');
+    });
+
+    it('refresh button is disabled while refreshing', async () => {
+      await mountWithData();
+
+      // Never resolve the post to keep it in "refreshing" state
+      axios.post.mockImplementation(() => new Promise(() => {}));
+
+      const refreshBtn = wrapper.find('[data-test="refresh-button"]');
+      await refreshBtn.trigger('click');
+      await wrapper.vm.$nextTick();
+
+      expect(refreshBtn.attributes('disabled')).toBeDefined();
+    });
+
+    it('shows error if cache invalidation fails', async () => {
+      await mountWithData();
+
+      axios.post.mockRejectedValueOnce(new Error('Cache error'));
+
+      const refreshBtn = wrapper.find('[data-test="refresh-button"]');
+      await refreshBtn.trigger('click');
+      await flushPromises();
+
+      expect(wrapper.find('[data-test="error"]').exists()).toBe(true);
+    });
+  });
 });


### PR DESCRIPTION
## Summary

- Adds an "Actualiser" button to the OnKindle page that invalidates the Calibre matching cache and reloads the data
- Adds a "Mise en cache 5 min" notice next to the book count to set user expectations about the caching delay
- Resolves the apparent mismatch reported in #249: books edited in Calibre (e.g. `onkindle` tag removed) could appear stale in the app for up to 5 minutes due to `CalibreMatchingService`'s in-memory cache

## Context

The original report described 3 books showing as "on Kindle" in the app that weren't actually on the Kindle. Investigation showed the virtual library filtering on `get_onkindle_books()` is by design (not a bug). The actual cause was `CalibreMatchingService`'s 5-minute in-memory cache: after the user removed the `onkindle` tag from those books in Calibre, the app continued showing stale cached data until the cache expired.

This fix reuses the existing `POST /api/calibre/cache/invalidate` endpoint (already implemented for the corrections workflow) by exposing it via a refresh button on the OnKindle page.

## Test plan

- [x] 5 new TDD tests added to `frontend/src/views/__tests__/OnKindle.spec.js` (cache info message, refresh button presence, click triggers invalidate + reload, button disabled while refreshing, error display on failure)
- [x] Frontend suite: 629/629 passing
- [x] Backend suite: 1378 passed, 23 skipped
- [x] `ruff check` and `mypy` clean
- [x] `mkdocs build --strict` succeeds
- [x] CI/CD pipeline green (frontend-tests, backend tests 3.11/3.12, security, integration-tests, quality-gate)

🤖 Generated with [Claude Code](https://claude.com/claude-code)