### PR TITLE
fix: detect Babelio 403 blocks explicitly and fix cookie UX (Issue #251)

### DIFF
--- a/docs/claude/memory/260622-1844-issue251-babelio-403-blocked-detection.md
+++ b/docs/claude/memory/260622-1844-issue251-babelio-403-blocked-detection.md
@@ -1,0 +1,153 @@
+# Issue #251 — Détection et signalement des blocages 403 Babelio (cookie silencieux)
+
+## Contexte du problème
+
+Après #247 (propagation du cookie `jstsToken`), les 403 Babelio sont revenus. Logs identiques :
+`WARNING - Babelio HTTP 403 pour: {titre}` en masse sur la page Livres et Auteurs.
+
+## Diagnostic en conditions réelles (devcontainer + VPN)
+
+Reproduit le problème en lançant le backend localement avec `BABELIO_DEBUG_LOG=1` et en observant
+les logs en temps réel pendant que l'utilisateur testait depuis le navigateur :
+
+- **Sans cookie** : 403 systématique sur `search()` (AJAX) ET sur `_fetch_page()` (scraping de
+  pages livre/auteur) — confirmé `Response status=403` dans les logs.
+- **Avec un cookie jstsToken frais collé dans l'UI** : 0% de 403 sur un cycle complet de
+  validation d'épisode.
+
+**Conclusion** : le mécanisme de cookie de #247 fonctionne toujours techniquement. Le vrai
+problème est l'absence totale de feedback/signal :
+
+1. **Échec silencieux** : `search()`/`_fetch_page()` loggaient un warning sur 403 mais
+   retournaient `[]`/`None` — strictement identique à "vraiment pas trouvé sur Babelio". Le
+   frontend recevait `status='not_found'` sans aucun moyen de savoir qu'un blocage anti-bot
+   avait eu lieu plutôt qu'une absence légitime.
+2. **Pas de confirmation de sauvegarde** : le bouton "Enregistrer" du cookie ne donnait aucun
+   retour visuel après clic — seule preuve : le petit badge "✓ configuré", facile à manquer.
+3. **Pas d'awareness d'expiration** : le `jstsToken` a une TTL ~5 min côté Babelio. Rien
+   n'avertissait l'utilisateur que son cookie précédemment sauvegardé était probablement devenu
+   obsolète.
+
+## Découverte additionnelle pendant les tests manuels (hors scope initial)
+
+En testant la page "Liaison Babelio des livres" (`BabelioMigration.vue`, endpoint
+`update_from_babelio_url`), l'erreur 403 apparaissait **même avec un cookie configuré** — page
+différente de `LivresAuteurs.vue`. Root cause distincte : cette page avait son propre champ
+cookie (fonctionnel pour `/api/babelio/extract-cover-url`) mais **`update_from_babelio_url()`
+n'avait pas de paramètre `babelio_cookies` du tout** dans toute la chaîne service → endpoint →
+frontend. Bug de propagation manquante, pas un problème de détection.
+
+## Solution retenue — 3 volets
+
+### 1. Backend : nouvelle exception `BabelioBlockedError`
+
+`src/back_office_lmelp/services/babelio_service.py:40-45` — exception dédiée levée sur HTTP 403,
+distincte des autres erreurs HTTP (503 etc. continuent de retourner `[]`/`None` comme avant).
+
+- `search()` : `elif response.status == 403: raise BabelioBlockedError(...)` avant le `else`
+  générique qui retourne `[]`. Le générique `except Exception` en fin de méthode re-raise
+  `BabelioBlockedError` explicitement (`except BabelioBlockedError: raise` ajouté avant le catch
+  générique) pour ne pas l'avaler.
+- `_fetch_page()` : même pattern, `if response.status == 403: raise BabelioBlockedError(...)`
+  avant le check `!= 200`.
+- `verify_author()` et `verify_book()` : nouveau bloc `except BabelioBlockedError:` qui renvoie
+  `status='blocked_403'` avec un `error_message` explicite, **avant** le catch générique
+  `except Exception`.
+
+**Piège critique** : `verify_book()` a 4 méthodes de scraping (`fetch_publisher_from_url`,
+`fetch_full_title_from_url`, `fetch_author_url_from_page`, `_scrape_author_from_book_page`)
+chacune avec son propre `try/except Exception` **interne** (pour ne pas faire échouer tout
+`verify_book()` si un enrichissement optionnel échoue). Sans `except BabelioBlockedError: raise`
+ajouté dans CES méthodes aussi, l'exception était avalée silencieusement avant même d'atteindre
+le catch de `verify_book()`. Il a fallu ajouter `except BabelioBlockedError: raise` dans :
+- Les 3 blocs `try` locaux dans `verify_book()` autour des appels d'enrichissement
+  (`babelio_service.py:724-766` zone éditeur/titre/URL auteur)
+- Les 4 méthodes de scraping elles-mêmes (chacune avait son propre `except Exception` interne)
+
+### 2. Frontend `LivresAuteurs.vue` : bannière + confirmation + badge expiration
+
+- `babelioBlocked` (bool) : affiche une bannière rouge `data-test="babelio-blocked-banner"` quand
+  `autoValidateAndSendResults()` détecte `validationResult.status === 'blocked_403'`. Reset à
+  `false` dans `saveBabelioCookie()`.
+- `babelioCookieSavedAt` / `babelioCookieJustSaved` : confirmation "✓ Cookie enregistré"
+  affichée 3s après clic sur Enregistrer (`setTimeout`, nettoyé dans `beforeUnmount`).
+- `babelioCookieLikelyExpired` (computed) : badge "⏰ probablement expiré" si
+  `Date.now() - babelioCookieSavedAt > 5min`. **Important** : reste `false` si
+  `babelioCookieSavedAt` est `null` (cookie restauré d'une session précédente sans date connue)
+  — évite un faux "expiré" non fondé.
+
+### 3. Frontend `BabelioMigration.vue` : alignement UX + fix propagation manquante
+
+- Ajout `babelio_cookies: this.babelioCookies || null` dans le POST `submitUrl()` vers
+  `/api/babelio-migration/update-from-url` (`BabelioMigration.vue:790`) — **1 ligne**, c'était
+  tout le bug de propagation manquante.
+- Backend : `update_from_babelio_url()` (`babelio_migration_service.py:720-727`) gagne le
+  paramètre `babelio_cookies: str | None = None`, propagé à `fetch_full_title_from_url()` et
+  `fetch_author_url_from_page()`. Endpoint `app.py` (`UpdateFromBabelioUrlRequest`) gagne le champ
+  `babelio_cookies`.
+- **Demande utilisateur explicite** : remplacer le pattern auto-save-on-input
+  (`@input="saveCookies"`) par le pattern explicite Enregistrer/Effacer de `LivresAuteurs.vue`,
+  pour cohérence UX entre les deux pages. Renommé `saveCookies()` → `saveBabelioCookie()` +
+  `clearBabelioCookie()`, ajout `babelioCookieInput` (brouillon) vs `babelioCookies` (valeur
+  sauvegardée réellement envoyée aux appels API).
+- **Demande utilisateur explicite** : déplacer le bloc cookie en haut de page (juste après le
+  titre `<h2>Migration Babelio</h2>`), avant la section stats "📚 Livres" — précédemment il était
+  enterré après 3 sections de stats + légendes.
+
+## Fichiers modifiés
+
+- `src/back_office_lmelp/services/babelio_service.py` — `BabelioBlockedError`, `search()`,
+  `_fetch_page()`, `verify_author()`, `verify_book()`, User-Agent bump Firefox/142→151
+- `src/back_office_lmelp/services/babelio_migration_service.py` — `update_from_babelio_url()`
+  gagne `babelio_cookies`
+- `src/back_office_lmelp/app.py` — `UpdateFromBabelioUrlRequest.babelio_cookies`
+- `frontend/src/views/LivresAuteurs.vue` — bannière 403, confirmation save, badge expiration
+- `frontend/src/views/BabelioMigration.vue` — boutons Enregistrer/Effacer, propagation cookie,
+  repositionnement du bloc en haut de page
+- `tests/test_babelio_403_detection.py` (nouveau, 7 tests)
+- `tests/test_babelio_cookies_propagation.py` — `test_fetch_page_returns_none_on_non_200` changé
+  de 403→503 (403 a maintenant son propre comportement dédié testé ailleurs)
+- `tests/test_update_from_babelio_url.py` — nouveau test propagation + assertions existantes
+  mises à jour avec `babelio_cookies=None`
+- `tests/test_update_from_url_endpoint.py` — nouveau test + assertions mises à jour
+- `frontend/tests/integration/LivresAuteurs.babelio403.test.js` (nouveau, 9 tests)
+- `frontend/tests/BabelioMigration.cookieButtons.test.js` (nouveau, 5 tests)
+- `frontend/tests/BabelioMigration.cookiePropagation.test.js` (nouveau, 2 tests)
+
+## Pièges rencontrés
+
+1. **Exceptions avalées par des `try/except Exception` imbriqués** : toujours vérifier TOUS les
+   niveaux d'imbrication des try/except quand on introduit une nouvelle exception à propager.
+   `verify_book()` avait 3 try/except locaux + 4 méthodes avec leur propre try/except = 7 points
+   où `except BabelioBlockedError: raise` était nécessaire avant le catch générique.
+
+2. **Tests existants à mettre à jour, pas seulement nouveaux tests** : changer le comportement
+   sur 403 a cassé `test_fetch_page_returns_none_on_non_200` (qui utilisait justement un mock à
+   403 pour tester le chemin générique "non-200"). Reflexe TDD : un changement de comportement
+   featuré a un coût sur les tests existants qui testaient l'ancien comportement par accident.
+
+3. **`git stash` + commande longue dans le même appel Bash** : `git stash && pytest ... && git
+   stash pop` chaîné en une seule commande peut donner l'impression que le stash pop n'a pas eu
+   lieu si la commande pytest est longue (le `git status` lancé en parallèle dans un autre appel
+   voit l'état stashé). Toujours attendre la fin réelle de la commande chaînée avant de vérifier
+   l'état git.
+
+4. **Tests réseau réels non mockés ralentissent `pytest tests/`** : `tests/test_radiofrance_pagination.py`
+   (classe `TestRadioFrancePaginationForOldEpisodes`, 4 tests) fait de vrais appels HTTP vers
+   radiofrance.fr, jusqu'à 150s+ par test. Découvert en attendant ~8 min qu'une suite complète
+   se termine. Tracé séparément dans l'issue #252 (à traiter plus tard, hors scope #251).
+
+## Vérification manuelle effectuée
+
+- Diagnostic confirmé en conditions réelles avec VPN + devcontainer sur la même IP (requis pour
+  que le cookie Babelio soit valide), logs `BABELIO_DEBUG_LOG=1` observés en direct.
+- Reproduit le 403 sans cookie, confirmé la résolution avec cookie frais, sur la page
+  LivresAuteurs.
+- Reproduit le bug de propagation manquante sur la page BabelioMigration ("Voir venir" + Lucile
+  Novat, erreur "Babelio 403 scraping" visible dans le popup "Entrer URL Babelio").
+- Validation finale par l'utilisateur sur les deux pages après tous les fix : "c'est parfait".
+
+## Issue connexe créée
+
+#252 — Tests `test_radiofrance_pagination.py` font de vrais appels réseau (lents/flaky), à
+traiter dans un futur cycle séparé.

--- a/docs/user/babelio-verification.md
+++ b/docs/user/babelio-verification.md
@@ -129,7 +129,7 @@ Lors du rafraîchissement, l'éditeur extrait est référencé dans la collectio
 
 ## Cookie Babelio (anti-bot)
 
-Babelio active parfois un système anti-bot qui bloque les requêtes automatiques avec une erreur 403. Pour contourner ce blocage, la page **Livres et Auteurs** propose une section **🔑 Cookie Babelio** permettant de fournir un cookie de session valide.
+Babelio active parfois un système anti-bot qui bloque les requêtes automatiques avec une erreur 403. Pour contourner ce blocage, les pages **Livres et Auteurs** et **Liaison Babelio des livres** proposent chacune une section **🔑 Cookie Babelio** (🍪 sur la page migration) permettant de fournir un cookie de session valide.
 
 ### Obtenir le cookie
 
@@ -141,14 +141,19 @@ Babelio active parfois un système anti-bot qui bloque les requêtes automatique
 
 ### Configurer le cookie dans l'interface
 
-1. Sur la page **Livres et Auteurs**, sélectionnez un épisode
-2. Cliquez sur la section **🔑 Cookie Babelio** (collapsible, au-dessus de la légende)
-3. Collez la valeur du cookie dans le champ de texte
-4. Cliquez sur **Enregistrer**
+1. Sur la page **Livres et Auteurs**, sélectionnez un épisode (ou ouvrez **Liaison Babelio des livres**, où le bloc cookie est affiché en haut de page)
+2. Collez la valeur du cookie dans le champ de texte
+3. Cliquez sur **Enregistrer**
 
-Le statut passe de ⚠ non configuré à ✓ configuré. Le cookie est stocké en `sessionStorage` (effacé à la fermeture de l'onglet) et transmis automatiquement à toutes les requêtes Babelio suivantes.
+Une confirmation "✓ Cookie enregistré" s'affiche brièvement, et le statut passe de ⚠ non configuré à ✓ configuré. Le cookie est stocké en `sessionStorage` (effacé à la fermeture de l'onglet) et transmis automatiquement à toutes les requêtes Babelio suivantes (validation, scraping de pages, migration manuelle par URL).
 
-**Durée de validité** : Le cookie `jstsToken` expire après 5 minutes. Si les erreurs 403 reviennent, répétez la procédure.
+**Durée de validité** : Le cookie `jstsToken` expire après 5 minutes. Passé ce délai, un badge **⏰ probablement expiré** remplace le ✓ configuré — pensez à rafraîchir le cookie avant de relancer un traitement long.
+
+**Détection automatique des blocages** : Si Babelio renvoie malgré tout une erreur 403 (cookie expiré en cours de traitement, par exemple), le système le détecte désormais explicitement :
+- Sur **Livres et Auteurs** : une bannière rouge ⚠️ s'affiche en haut de page
+- Sur **Liaison Babelio des livres** : le message d'erreur du popup contient "403"
+
+Dans les deux cas, la solution est la même : rafraîchir le cookie et relancer.
 
 ## Limitations connues
 
@@ -249,23 +254,17 @@ Le système récupère automatiquement les URLs de couvertures des livres depuis
 
 ### Pré-requis : cookie Babelio
 
-Le scraping de couvertures (et plus généralement toutes les extractions depuis les pages Babelio) peut nécessiter un cookie de session valide si Babelio active sa protection anti-bot. Ce cookie est fourni par le navigateur, pas le serveur.
+Le scraping de couvertures (et plus généralement toutes les extractions depuis les pages Babelio, y compris la mise à jour manuelle par URL) peut nécessiter un cookie de session valide si Babelio active sa protection anti-bot. Ce cookie est fourni par le navigateur, pas le serveur.
 
-**Obtenir le cookie Babelio :**
-1. Ouvrez [babelio.com](https://www.babelio.com) dans votre navigateur
-2. Appuyez sur **F12** → onglet **Réseau** (Network)
-3. Rechargez la page (F5)
-4. Cliquez sur la première requête vers `babelio.com`
-5. Dans l'onglet **En-têtes** → **En-têtes de la requête** → copiez la valeur du champ **Cookie**
-6. Collez cette valeur dans la zone de texte de la section Couvertures
+Le bloc **🍪 Cookie Babelio** est affiché en haut de la page `/babelio-migration` (juste sous le titre), avant les statistiques — il est partagé par toutes les sections de la page (liaison automatique, couvertures, URL manuelle).
 
-Le cookie est stocké temporairement dans le `sessionStorage` du navigateur et effacé à la fermeture de l'onglet.
+**Obtenir le cookie Babelio :** voir la procédure détaillée dans [Cookie Babelio (anti-bot)](#cookie-babelio-anti-bot) plus haut dans ce document.
 
 ### Lancer la migration des couvertures
 
 Dans `/babelio-migration`, section **Couvertures** :
 
-1. Collez votre cookie Babelio dans la zone prévue
+1. Vérifiez que le cookie Babelio est configuré (✓ configuré en haut de page)
 2. Cliquez sur **Lancer la liaison des couvertures**
 3. Le système traite les livres un par un, avec un délai de 5 secondes entre chaque requête
 4. Les résultats s'affichent en temps réel :

--- a/docs/user/troubleshooting.md
+++ b/docs/user/troubleshooting.md
@@ -353,9 +353,10 @@ localStorage.debug = '*'
 ### Validation Babelio bloquée (erreurs 403)
 
 **Symptômes :**
-- Les validations livres/auteurs échouent toutes
-- Statut ⚠️ Erreur sur tous les livres d'un épisode
-- Logs backend : `WARNING - Babelio HTTP 403 pour: {titre}`
+- Une bannière rouge ⚠️ "Babelio a bloqué les requêtes (403)" apparaît en haut de la page
+  **Livres et Auteurs**
+- Sur la page **Liaison Babelio des livres**, le message d'erreur affiché contient "403"
+- Logs backend : `WARNING - Babelio HTTP 403 pour: {titre} - cookie requis`
 
 **Cause :** Babelio a détecté un accès automatique depuis l'IP du serveur et a activé une protection anti-bot.
 
@@ -366,11 +367,18 @@ localStorage.debug = '*'
 3. Appuyez sur **F12** → onglet **Réseau** → rechargez la page (F5)
 4. Cliquez sur la première requête vers `babelio.com`
 5. Dans **En-têtes de la requête**, copiez la valeur complète du champ **Cookie**
-6. Dans la page **Livres et Auteurs**, sélectionnez un épisode puis cliquez sur **🔑 Cookie Babelio**
-7. Collez la valeur et cliquez **Enregistrer**
+6. Dans la page **Livres et Auteurs** (ou **Liaison Babelio des livres**), collez la valeur dans
+   le champ **🍪 Cookie Babelio** et cliquez **Enregistrer**
+7. Une confirmation "✓ Cookie enregistré" s'affiche ; la bannière de blocage disparaît
 8. Relancez les validations
 
-**Durée de validité :** Le cookie expire après ~5 minutes. Si le blocage revient, répétez la procédure.
+**Durée de validité :** Le cookie expire après ~5 minutes. Passé ce délai, un badge "⏰
+probablement expiré" apparaît à côté du champ cookie. Si le blocage revient (nouvelle bannière
+rouge ou nouveau message contenant "403"), répétez la procédure.
+
+**Note :** Avant cette détection, un blocage 403 apparaissait silencieusement comme "Non trouvé"
+sur Babelio — sans bannière ni message distinct. Si vous voyez beaucoup de livres "Non trouvé"
+d'un coup sur un épisode entier, vérifiez d'abord que le cookie n'est pas expiré.
 
 ---
 

--- a/frontend/src/views/BabelioMigration.vue
+++ b/frontend/src/views/BabelioMigration.vue
@@ -13,6 +13,44 @@
     <div v-if="status" class="status-panel">
       <h2>{{ migrationProgress.is_running ? '⚙️ Liaison en cours' : 'Migration Babelio' }}</h2>
 
+      <!-- Cookie Babelio -->
+      <div class="cookie-section">
+        <div class="cookie-header">
+          <label>🍪 Cookie Babelio
+            <span class="cookie-status" v-if="babelioCookieStored">✅ configuré</span>
+            <span class="cookie-status missing" v-else>⚠️ non configuré (couvertures limitées)</span>
+          </label>
+          <button class="btn-link" @click="showCookieHelp = !showCookieHelp">
+            {{ showCookieHelp ? 'Masquer' : 'Comment faire ?' }}
+          </button>
+        </div>
+        <div v-if="showCookieHelp" class="cookie-help">
+          <ol>
+            <li>Ouvre <a href="https://www.babelio.com" target="_blank">babelio.com</a> et connecte-toi</li>
+            <li>Ouvre les DevTools (F12) → onglet <strong>Réseau</strong></li>
+            <li>Recharge la page babelio.com, clique sur la 1ère requête</li>
+            <li>Dans <strong>Network > Headers > Request Headers</strong>, copie la valeur du champ <strong>Cookie</strong> (bouton droit, Copy Value)</li>
+            <li>Colle-la ci-dessous</li>
+            <li>💡 Si le captcha revient pendant la migration, répète ces étapes</li>
+          </ol>
+        </div>
+        <textarea
+          v-model="babelioCookieInput"
+          placeholder="Colle ici la valeur du header Cookie copié depuis les DevTools de babelio.com..."
+          class="cookie-input"
+          rows="2"
+        ></textarea>
+        <div class="cookie-actions">
+          <button @click="saveBabelioCookie" class="btn-save-cookie" :disabled="!babelioCookieInput.trim()">
+            Enregistrer
+          </button>
+          <button v-if="babelioCookieStored" @click="clearBabelioCookie" class="btn-clear-cookie">
+            Effacer
+          </button>
+          <span v-if="babelioCookieJustSaved" class="cookie-saved-confirmation" data-test="cookie-saved-confirmation">✓ Cookie enregistré</span>
+        </div>
+      </div>
+
       <!-- Statistiques Livres -->
       <h3 class="stats-section-title">📚 Livres</h3>
       <div class="stats-grid">
@@ -133,36 +171,6 @@
           <li><strong>À traiter manuellement:</strong> Livres dont la page Babelio affiche un autre livre (redirection)</li>
           <li><strong>En attente de liaison:</strong> Livres avec URL Babelio mais sans couverture encore récupérée</li>
         </ul>
-      </div>
-
-      <!-- Cookie Babelio -->
-      <div class="cookie-section">
-        <div class="cookie-header">
-          <label>🍪 Cookie Babelio
-            <span class="cookie-status" v-if="babelioCookies">✅ configuré</span>
-            <span class="cookie-status missing" v-else>⚠️ non configuré (couvertures limitées)</span>
-          </label>
-          <button class="btn-link" @click="showCookieHelp = !showCookieHelp">
-            {{ showCookieHelp ? 'Masquer' : 'Comment faire ?' }}
-          </button>
-        </div>
-        <div v-if="showCookieHelp" class="cookie-help">
-          <ol>
-            <li>Ouvre <a href="https://www.babelio.com" target="_blank">babelio.com</a> et connecte-toi</li>
-            <li>Ouvre les DevTools (F12) → onglet <strong>Réseau</strong></li>
-            <li>Recharge la page babelio.com, clique sur la 1ère requête</li>
-            <li>Dans <strong>Network > Headers > Request Headers</strong>, copie la valeur du champ <strong>Cookie</strong> (bouton droit, Copy Value)</li>
-            <li>Colle-la ci-dessous</li>
-            <li>💡 Si le captcha revient pendant la migration, répète ces étapes</li>
-          </ol>
-        </div>
-        <textarea
-          v-model="babelioCookies"
-          @input="saveCookies"
-          placeholder="Colle ici la valeur du header Cookie copié depuis les DevTools de babelio.com..."
-          class="cookie-input"
-          rows="2"
-        ></textarea>
       </div>
 
       <!-- Cover migration button -->
@@ -593,6 +601,10 @@ export default {
       coverMismatchCases: [],
       coverUrlInputs: {}, // { [livre_id]: url_string }
       babelioCookies: sessionStorage.getItem('babelio_cookies') || '',
+      babelioCookieInput: sessionStorage.getItem('babelio_cookies') || '',
+      babelioCookieStored: !!sessionStorage.getItem('babelio_cookies'),
+      babelioCookieJustSaved: false,
+      babelioCookieSavedConfirmationTimeout: null,
       showCookieHelp: false,
       // Popup pour entrer URL Babelio
       showUrlPopup: false,
@@ -613,6 +625,10 @@ export default {
     }
     // Arrêter la migration des couvertures si en cours
     this.stopCoverMigration_flag = true;
+    if (this.babelioCookieSavedConfirmationTimeout) {
+      clearTimeout(this.babelioCookieSavedConfirmationTimeout);
+      this.babelioCookieSavedConfirmationTimeout = null;
+    }
   },
   computed: {
     totalItemsToProcess() {
@@ -775,6 +791,7 @@ export default {
           item_id: itemId,
           babelio_url: this.babelioUrl.trim(),
           item_type: itemType,
+          babelio_cookies: this.babelioCookies || null,
         });
 
         if (response.data.status === 'success') {
@@ -1081,8 +1098,28 @@ export default {
       }
     },
 
-    saveCookies() {
-      sessionStorage.setItem('babelio_cookies', this.babelioCookies);
+    saveBabelioCookie() {
+      const val = this.babelioCookieInput.trim();
+      if (val) {
+        sessionStorage.setItem('babelio_cookies', val);
+        this.babelioCookies = val;
+        this.babelioCookieStored = true;
+
+        this.babelioCookieJustSaved = true;
+        if (this.babelioCookieSavedConfirmationTimeout) {
+          clearTimeout(this.babelioCookieSavedConfirmationTimeout);
+        }
+        this.babelioCookieSavedConfirmationTimeout = setTimeout(() => {
+          this.babelioCookieJustSaved = false;
+        }, 3000);
+      }
+    },
+
+    clearBabelioCookie() {
+      sessionStorage.removeItem('babelio_cookies');
+      this.babelioCookies = '';
+      this.babelioCookieInput = '';
+      this.babelioCookieStored = false;
     },
 
     async _extractCoverUrlFromBabelioPage(babelioUrl, expectedTitle = null) {
@@ -1407,6 +1444,43 @@ h2 {
   border-radius: 4px;
   resize: vertical;
   color: #495057;
+}
+
+.cookie-actions {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  margin-top: 0.5rem;
+}
+
+.btn-save-cookie {
+  padding: 4px 12px;
+  background: #0d6efd;
+  color: white;
+  border: none;
+  border-radius: 4px;
+  cursor: pointer;
+  font-size: 0.8rem;
+}
+
+.btn-save-cookie:disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
+}
+
+.btn-clear-cookie {
+  padding: 4px 12px;
+  background: #6c757d;
+  color: white;
+  border: none;
+  border-radius: 4px;
+  cursor: pointer;
+  font-size: 0.8rem;
+}
+
+.cookie-saved-confirmation {
+  font-size: 0.8rem;
+  color: #155724;
 }
 
 .migration-button-container {

--- a/frontend/src/views/LivresAuteurs.vue
+++ b/frontend/src/views/LivresAuteurs.vue
@@ -63,13 +63,20 @@
           </div>
         </div>
 
+      <!-- Alerte blocage Babelio 403 (Issue #251) -->
+      <div v-if="babelioBlocked" class="babelio-blocked-banner" data-test="babelio-blocked-banner">
+        ⚠️ Babelio a bloqué les requêtes (403). Le cookie est probablement expiré (TTL ~5 min) — collez un cookie frais ci-dessous.
+        <button @click="babelioBlocked = false" class="babelio-blocked-banner-close" aria-label="Fermer">✕</button>
+      </div>
+
       <!-- Cookie Babelio (jstsToken) — nécessaire pour les requêtes AJAX Issue #247 -->
       <section v-if="selectedEpisodeId" class="babelio-cookie-section">
         <details>
           <summary class="babelio-cookie-summary">
             🔑 Cookie Babelio
-            <span v-if="babelioCookieStored" class="cookie-status cookie-ok">✓ configuré</span>
-            <span v-else class="cookie-status cookie-missing">⚠ non configuré (risque 403)</span>
+            <span v-if="!babelioCookieStored" class="cookie-status cookie-missing">⚠ non configuré (risque 403)</span>
+            <span v-else-if="babelioCookieLikelyExpired" class="cookie-status cookie-expired" data-test="cookie-expired-badge">⏰ probablement expiré — actualisez-le</span>
+            <span v-else class="cookie-status cookie-ok">✓ configuré</span>
           </summary>
           <div class="babelio-cookie-form">
             <p class="cookie-help">
@@ -90,6 +97,7 @@
               <button v-if="babelioCookieStored" @click="clearBabelioCookie" class="btn-clear-cookie">
                 Effacer
               </button>
+              <span v-if="babelioCookieJustSaved" class="cookie-saved-confirmation" data-test="cookie-saved-confirmation">✓ Cookie enregistré</span>
             </div>
           </div>
         </details>
@@ -707,11 +715,20 @@ export default {
   // Issue #247: Cookie Babelio (jstsToken) pour éviter les 403
   babelioCookieInput: sessionStorage.getItem('babelio_cookies') || '',
   babelioCookieStored: !!sessionStorage.getItem('babelio_cookies'),
+  // Issue #251: feedback de blocage 403, confirmation de sauvegarde, expiration
+  babelioBlocked: false,
+  babelioCookieSavedAt: null,
+  babelioCookieJustSaved: false,
+  babelioCookieSavedConfirmationTimeout: null,
 
     };
   },
 
   computed: {
+    babelioCookieLikelyExpired() {
+      if (!this.babelioCookieSavedAt) return false;
+      return (Date.now() - this.babelioCookieSavedAt) > 5 * 60 * 1000;
+    },
     selectedEpisode() {
       if (!this.selectedEpisodeId) return null;
       return this.episodesWithReviews.find(ep => String(ep.id) === String(this.selectedEpisodeId));
@@ -883,6 +900,10 @@ export default {
 
   beforeUnmount() {
     if (this._onKeydown) window.removeEventListener('keydown', this._onKeydown, true);
+    if (this.babelioCookieSavedConfirmationTimeout) {
+      clearTimeout(this.babelioCookieSavedConfirmationTimeout);
+      this.babelioCookieSavedConfirmationTimeout = null;
+    }
   },
 
   methods: {
@@ -1585,6 +1606,16 @@ export default {
       if (val) {
         sessionStorage.setItem('babelio_cookies', val);
         this.babelioCookieStored = true;
+        this.babelioCookieSavedAt = Date.now();
+        this.babelioBlocked = false;
+
+        this.babelioCookieJustSaved = true;
+        if (this.babelioCookieSavedConfirmationTimeout) {
+          clearTimeout(this.babelioCookieSavedConfirmationTimeout);
+        }
+        this.babelioCookieSavedConfirmationTimeout = setTimeout(() => {
+          this.babelioCookieJustSaved = false;
+        }, 3000);
       }
     },
 
@@ -1609,6 +1640,12 @@ export default {
               book.editeur || '',
               this.selectedEpisodeId
             );
+
+            // Issue #251: Babelio a bloqué la requête (403) — signaler à l'utilisateur
+            // qu'il doit rafraîchir son cookie, distinct d'un "not_found" légitime
+            if (validationResult.status === 'blocked_403') {
+              this.babelioBlocked = true;
+            }
 
             // Convertir le résultat de validation au format backend
             let status = validationResult.status;
@@ -3075,5 +3112,40 @@ export default {
   border-radius: 4px;
   cursor: pointer;
   font-size: 0.8rem;
+}
+
+.cookie-expired {
+  background: #ffe5b4;
+  color: #8a5a00;
+}
+
+.cookie-saved-confirmation {
+  font-size: 0.8rem;
+  color: #155724;
+  align-self: center;
+}
+
+/* Issue #251: Bannière de blocage Babelio 403 */
+.babelio-blocked-banner {
+  margin: 0.5rem 1rem;
+  padding: 0.75rem 1rem;
+  background: #f8d7da;
+  color: #721c24;
+  border: 1px solid #f5c2c7;
+  border-radius: 6px;
+  font-size: 0.85rem;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 0.5rem;
+}
+
+.babelio-blocked-banner-close {
+  background: none;
+  border: none;
+  color: #721c24;
+  cursor: pointer;
+  font-size: 1rem;
+  line-height: 1;
 }
 </style>

--- a/frontend/tests/BabelioMigration.cookieButtons.test.js
+++ b/frontend/tests/BabelioMigration.cookieButtons.test.js
@@ -1,0 +1,135 @@
+/**
+ * Tests TDD pour les boutons Enregistrer/Effacer du cookie Babelio sur la page
+ * "Liaison Babelio des livres" (Issue #251).
+ *
+ * Contexte: cette page sauvegardait le cookie automatiquement à chaque frappe
+ * (@input="saveCookies") sans boutons explicites Enregistrer/Effacer, contrairement
+ * à la page LivresAuteurs.vue. Alignement demandé par l'utilisateur pour cohérence
+ * UX entre les deux pages.
+ */
+
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { mount } from '@vue/test-utils';
+import BabelioMigration from '../src/views/BabelioMigration.vue';
+import axios from 'axios';
+
+vi.mock('axios');
+
+const RouterLinkStub = {
+  template: '<a><slot /></a>',
+};
+
+describe('BabelioMigration - Boutons Enregistrer/Effacer cookie (Issue #251)', () => {
+  let wrapper;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    sessionStorage.clear();
+  });
+
+  afterEach(() => {
+    if (wrapper) {
+      wrapper.unmount();
+    }
+    sessionStorage.clear();
+    vi.useRealTimers();
+  });
+
+  function mountComponent() {
+    axios.get.mockResolvedValue({ data: {} });
+    return mount(BabelioMigration, {
+      global: {
+        stubs: { 'router-link': RouterLinkStub },
+        mocks: { $route: { path: '/babelio-migration' } },
+      },
+    });
+  }
+
+  it("n'enregistre pas le cookie tant que le bouton Enregistrer n'est pas cliqué", async () => {
+    wrapper = mountComponent();
+    await wrapper.vm.$nextTick();
+
+    wrapper.vm.babelioCookieInput = 'jstsToken=abc123; p=FR; disclaimer=1';
+    await wrapper.vm.$nextTick();
+
+    expect(sessionStorage.getItem('babelio_cookies')).toBeNull();
+    expect(wrapper.vm.babelioCookies).toBe('');
+  });
+
+  it('enregistre le cookie dans sessionStorage et babelioCookies au clic sur Enregistrer', async () => {
+    wrapper = mountComponent();
+    await wrapper.vm.$nextTick();
+
+    wrapper.vm.babelioCookieInput = 'jstsToken=abc123; p=FR; disclaimer=1';
+    wrapper.vm.saveBabelioCookie();
+    await wrapper.vm.$nextTick();
+
+    expect(sessionStorage.getItem('babelio_cookies')).toBe('jstsToken=abc123; p=FR; disclaimer=1');
+    expect(wrapper.vm.babelioCookies).toBe('jstsToken=abc123; p=FR; disclaimer=1');
+    expect(wrapper.vm.babelioCookieStored).toBe(true);
+  });
+
+  it('affiche une confirmation après la sauvegarde', async () => {
+    vi.useFakeTimers();
+    wrapper = mountComponent();
+    await wrapper.vm.$nextTick();
+    vi.useFakeTimers();
+
+    wrapper.vm.babelioCookieInput = 'jstsToken=abc123; p=FR; disclaimer=1';
+    wrapper.vm.saveBabelioCookie();
+    await wrapper.vm.$nextTick();
+
+    expect(wrapper.vm.babelioCookieJustSaved).toBe(true);
+
+    vi.advanceTimersByTime(3100);
+    await wrapper.vm.$nextTick();
+
+    expect(wrapper.vm.babelioCookieJustSaved).toBe(false);
+  });
+
+  it('efface le cookie au clic sur Effacer', async () => {
+    sessionStorage.setItem('babelio_cookies', 'jstsToken=old; p=FR; disclaimer=1');
+    wrapper = mountComponent();
+    await wrapper.vm.$nextTick();
+
+    expect(wrapper.vm.babelioCookieStored).toBe(true);
+
+    wrapper.vm.clearBabelioCookie();
+    await wrapper.vm.$nextTick();
+
+    expect(sessionStorage.getItem('babelio_cookies')).toBeNull();
+    expect(wrapper.vm.babelioCookies).toBe('');
+    expect(wrapper.vm.babelioCookieStored).toBe(false);
+  });
+
+  it('transmet le cookie sauvegardé (pas la saisie en cours non sauvegardée) à update-from-url', async () => {
+    wrapper = mountComponent();
+    await wrapper.vm.$nextTick();
+
+    wrapper.vm.babelioCookieInput = 'jstsToken=saved; p=FR; disclaimer=1';
+    wrapper.vm.saveBabelioCookie();
+    await wrapper.vm.$nextTick();
+
+    // L'utilisateur tape un nouveau brouillon sans cliquer Enregistrer
+    wrapper.vm.babelioCookieInput = 'jstsToken=draft-not-saved';
+
+    wrapper.vm.babelioUrl = 'https://www.babelio.com/livres/Test/123';
+    wrapper.vm.urlPopupCase = {
+      type: 'livre',
+      livre_id: 'livre-id-1',
+      titre_attendu: 'Titre Test',
+    };
+    axios.post.mockResolvedValue({
+      data: { status: 'success', message: 'Livre mis à jour', data: {} },
+    });
+
+    await wrapper.vm.submitUrl();
+
+    expect(axios.post).toHaveBeenCalledWith(
+      '/api/babelio-migration/update-from-url',
+      expect.objectContaining({
+        babelio_cookies: 'jstsToken=saved; p=FR; disclaimer=1',
+      })
+    );
+  });
+});

--- a/frontend/tests/BabelioMigration.cookiePropagation.test.js
+++ b/frontend/tests/BabelioMigration.cookiePropagation.test.js
@@ -1,0 +1,97 @@
+/**
+ * Tests TDD pour la propagation du cookie Babelio dans submitUrl() (Issue #251).
+ *
+ * Contexte: la page "Liaison Babelio des livres" (BabelioMigration.vue) a un champ
+ * de cookie Babelio déjà fonctionnel pour /api/babelio/extract-cover-url, mais
+ * l'appel à /api/babelio-migration/update-from-url oubliait de le transmettre,
+ * causant des 403 silencieux même quand l'utilisateur avait fourni un cookie valide.
+ */
+
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { mount } from '@vue/test-utils';
+import BabelioMigration from '../src/views/BabelioMigration.vue';
+import axios from 'axios';
+
+vi.mock('axios');
+
+const RouterLinkStub = {
+  template: '<a><slot /></a>',
+};
+
+describe('BabelioMigration - Propagation cookie Babelio (Issue #251)', () => {
+  let wrapper;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    sessionStorage.clear();
+  });
+
+  afterEach(() => {
+    if (wrapper) {
+      wrapper.unmount();
+    }
+    sessionStorage.clear();
+  });
+
+  function mountComponent() {
+    axios.get.mockResolvedValue({ data: {} });
+    return mount(BabelioMigration, {
+      global: {
+        stubs: { 'router-link': RouterLinkStub },
+        mocks: { $route: { path: '/babelio-migration' } },
+      },
+    });
+  }
+
+  it('transmet babelio_cookies à update-from-url quand un cookie est configuré', async () => {
+    wrapper = mountComponent();
+    await wrapper.vm.$nextTick();
+
+    wrapper.vm.babelioCookies = 'jstsToken=abc123; p=FR; disclaimer=1';
+    wrapper.vm.babelioUrl = 'https://www.babelio.com/livres/Test/123';
+    wrapper.vm.urlPopupCase = {
+      type: 'livre',
+      livre_id: 'livre-id-1',
+      titre_attendu: 'Titre Test',
+    };
+
+    axios.post.mockResolvedValue({
+      data: { status: 'success', message: 'Livre mis à jour', data: {} },
+    });
+
+    await wrapper.vm.submitUrl();
+
+    expect(axios.post).toHaveBeenCalledWith(
+      '/api/babelio-migration/update-from-url',
+      expect.objectContaining({
+        babelio_cookies: 'jstsToken=abc123; p=FR; disclaimer=1',
+      })
+    );
+  });
+
+  it('transmet babelio_cookies=null quand aucun cookie configuré', async () => {
+    wrapper = mountComponent();
+    await wrapper.vm.$nextTick();
+
+    wrapper.vm.babelioCookies = '';
+    wrapper.vm.babelioUrl = 'https://www.babelio.com/livres/Test/123';
+    wrapper.vm.urlPopupCase = {
+      type: 'livre',
+      livre_id: 'livre-id-1',
+      titre_attendu: 'Titre Test',
+    };
+
+    axios.post.mockResolvedValue({
+      data: { status: 'success', message: 'Livre mis à jour', data: {} },
+    });
+
+    await wrapper.vm.submitUrl();
+
+    expect(axios.post).toHaveBeenCalledWith(
+      '/api/babelio-migration/update-from-url',
+      expect.objectContaining({
+        babelio_cookies: null,
+      })
+    );
+  });
+});

--- a/frontend/tests/integration/LivresAuteurs.babelio403.test.js
+++ b/frontend/tests/integration/LivresAuteurs.babelio403.test.js
@@ -1,0 +1,225 @@
+/**
+ * Tests TDD pour la détection des blocages Babelio 403 et le feedback cookie (Issue #251).
+ *
+ * Contexte: Issue #247 a ajouté un mécanisme de cookie Babelio (jstsToken) mais
+ * sans feedback visible quand Babelio bloque réellement les requêtes (403).
+ * Le backend renvoie désormais status='blocked_403' au lieu de 'not_found'
+ * quand un blocage anti-bot est détecté.
+ *
+ * Cette suite vérifie que le frontend :
+ * 1. Affiche une bannière d'alerte quand un 403 est détecté
+ * 2. Confirme visuellement la sauvegarde du cookie
+ * 3. Affiche un badge "probablement expiré" après 5 minutes
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { mount } from '@vue/test-utils';
+import { createRouter, createWebHistory } from 'vue-router';
+import LivresAuteurs from '../../src/views/LivresAuteurs.vue';
+import { livresAuteursService } from '../../src/services/api.js';
+import BiblioValidationService from '../../src/services/BiblioValidationService.js';
+
+vi.mock('../../src/services/api.js', () => ({
+  livresAuteursService: {
+    getLivresAuteurs: vi.fn(),
+    getEpisodesWithReviews: vi.fn(),
+    getCollectionsStatistics: vi.fn(),
+    autoProcessVerifiedBooks: vi.fn(),
+    autoProcessVerified: vi.fn(),
+    getBooksByValidationStatus: vi.fn(),
+    validateSuggestion: vi.fn(),
+    addManualBook: vi.fn(),
+    getAllAuthors: vi.fn(),
+    getAllBooks: vi.fn(),
+    setValidationResults: vi.fn(),
+    deleteCacheByEpisode: vi.fn(),
+  },
+  episodeService: {
+    getAllEpisodes: vi.fn(),
+    getEpisodeById: vi.fn(),
+    updateEpisodeDescription: vi.fn(),
+    updateEpisodeTitle: vi.fn(),
+  },
+  statisticsService: {
+    getStatistics: vi.fn(),
+  },
+  babelioService: {
+    verifyAuthor: vi.fn(),
+    verifyBook: vi.fn(),
+    verifyPublisher: vi.fn(),
+  },
+  fuzzySearchService: {
+    searchEpisode: vi.fn(),
+  },
+}));
+
+describe('LivresAuteurs - Détection blocage Babelio 403 (Issue #251)', () => {
+  let wrapper;
+  let router;
+
+  const mockEpisodesWithReviews = [
+    {
+      _id: { $oid: '6865f995a1418e3d7c63d076' }, // pragma: allowlist secret
+      titre: 'Episode test',
+      date: '29 juin 2025',
+      review_count: 1,
+    },
+  ];
+
+  beforeEach(async () => {
+    vi.clearAllMocks();
+    sessionStorage.clear();
+    BiblioValidationService._extractedBooksCache?.clear();
+
+    router = createRouter({
+      history: createWebHistory(),
+      routes: [
+        { path: '/', component: { template: '<div>Dashboard</div>' } },
+        { path: '/livres-auteurs', component: LivresAuteurs },
+      ],
+    });
+    await router.push('/livres-auteurs');
+  });
+
+  afterEach(() => {
+    if (wrapper) {
+      wrapper.unmount();
+    }
+    sessionStorage.clear();
+    vi.useRealTimers();
+  });
+
+  async function mountPage() {
+    livresAuteursService.getEpisodesWithReviews.mockResolvedValue(mockEpisodesWithReviews);
+    wrapper = mount(LivresAuteurs, {
+      global: { plugins: [router] },
+    });
+    await wrapper.vm.$nextTick();
+    await new Promise((resolve) => setTimeout(resolve, 50));
+    return wrapper;
+  }
+
+  describe('Bannière de blocage 403', () => {
+    it('ne montre pas la bannière par défaut', async () => {
+      await mountPage();
+      expect(wrapper.vm.babelioBlocked).toBe(false);
+      expect(wrapper.find('[data-test="babelio-blocked-banner"]').exists()).toBe(false);
+    });
+
+    it('affiche la bannière quand babelioBlocked est mis à true', async () => {
+      await mountPage();
+      wrapper.vm.babelioBlocked = true;
+      await wrapper.vm.$nextTick();
+
+      const banner = wrapper.find('[data-test="babelio-blocked-banner"]');
+      expect(banner.exists()).toBe(true);
+      expect(banner.text()).toContain('403');
+    });
+
+    it('efface la bannière en sauvegardant un nouveau cookie', async () => {
+      await mountPage();
+      wrapper.vm.babelioBlocked = true;
+      wrapper.vm.babelioCookieInput = 'jstsToken=fresh123; p=FR; disclaimer=1';
+      wrapper.vm.saveBabelioCookie();
+      await wrapper.vm.$nextTick();
+
+      expect(wrapper.vm.babelioBlocked).toBe(false);
+    });
+  });
+
+  describe('Confirmation de sauvegarde du cookie', () => {
+    it('affiche un message de confirmation après saveBabelioCookie()', async () => {
+      await mountPage();
+      vi.useFakeTimers();
+
+      wrapper.vm.babelioCookieInput = 'jstsToken=abc123; p=FR; disclaimer=1';
+      wrapper.vm.saveBabelioCookie();
+      await wrapper.vm.$nextTick();
+
+      expect(wrapper.vm.babelioCookieJustSaved).toBe(true);
+
+      vi.advanceTimersByTime(3100);
+      await wrapper.vm.$nextTick();
+
+      expect(wrapper.vm.babelioCookieJustSaved).toBe(false);
+    });
+
+    it("n'affiche pas de confirmation si le champ cookie est vide", async () => {
+      await mountPage();
+
+      wrapper.vm.babelioCookieInput = '   ';
+      wrapper.vm.saveBabelioCookie();
+      await wrapper.vm.$nextTick();
+
+      expect(wrapper.vm.babelioCookieJustSaved).toBe(false);
+    });
+  });
+
+  describe('Badge d\'expiration probable (TTL ~5min)', () => {
+    it('ne considère pas le cookie comme expiré juste après sauvegarde', async () => {
+      await mountPage();
+
+      wrapper.vm.babelioCookieInput = 'jstsToken=abc123; p=FR; disclaimer=1';
+      wrapper.vm.saveBabelioCookie();
+      await wrapper.vm.$nextTick();
+
+      expect(wrapper.vm.babelioCookieLikelyExpired).toBe(false);
+    });
+
+    it('considère le cookie comme probablement expiré après 5 minutes', async () => {
+      await mountPage();
+
+      wrapper.vm.babelioCookieInput = 'jstsToken=abc123; p=FR; disclaimer=1';
+      wrapper.vm.saveBabelioCookie();
+      await wrapper.vm.$nextTick();
+
+      // babelioCookieLikelyExpired compare Date.now() à babelioCookieSavedAt:
+      // on recule artificiellement la date de sauvegarde plutôt que d'avancer
+      // une fausse horloge (évite les conflits avec le setTimeout de confirmation).
+      wrapper.vm.babelioCookieSavedAt = Date.now() - (5 * 60 * 1000 + 1000);
+      await wrapper.vm.$nextTick();
+
+      expect(wrapper.vm.babelioCookieLikelyExpired).toBe(true);
+    });
+
+    it('ne marque pas un cookie pré-existant (session précédente) comme expiré sans date connue', async () => {
+      sessionStorage.setItem('babelio_cookies', 'jstsToken=old; p=FR; disclaimer=1');
+      await mountPage();
+
+      // Pas de babelioCookieSavedAt connu pour ce cookie restauré depuis une session précédente
+      expect(wrapper.vm.babelioCookieSavedAt).toBeNull();
+      expect(wrapper.vm.babelioCookieLikelyExpired).toBe(false);
+    });
+  });
+
+  describe('Détection du status blocked_403 lors de la validation', () => {
+    it('active babelioBlocked quand autoValidateAndSendResults reçoit status=blocked_403', async () => {
+      const mockBooks = [
+        {
+          episode_oid: '6865f995a1418e3d7c63d076', // pragma: allowlist secret
+          auteur: 'Boualem Sansal',
+          titre: 'La Légende',
+          editeur: 'Grasset',
+          validation_status: null,
+          programme: false,
+        },
+      ];
+
+      livresAuteursService.getLivresAuteurs.mockResolvedValue(mockBooks);
+      livresAuteursService.setValidationResults.mockResolvedValue({ success: true });
+
+      await mountPage();
+
+      wrapper.vm.books = mockBooks;
+      vi.spyOn(BiblioValidationService, 'validateBiblio').mockResolvedValue({
+        status: 'blocked_403',
+        error_message: 'Babelio a bloqué la requête (403).',
+      });
+
+      await wrapper.vm.autoValidateAndSendResults();
+      await wrapper.vm.$nextTick();
+
+      expect(wrapper.vm.babelioBlocked).toBe(true);
+    });
+  });
+});

--- a/src/back_office_lmelp/app.py
+++ b/src/back_office_lmelp/app.py
@@ -236,6 +236,7 @@ class UpdateFromBabelioUrlRequest(BaseModel):
     item_id: str
     babelio_url: str
     item_type: str = "livre"  # "livre" ou "auteur"
+    babelio_cookies: str | None = None  # Cookie header copié depuis DevTools
 
 
 class ExtractFromBabelioUrlRequest(BaseModel):
@@ -3278,6 +3279,7 @@ async def update_from_babelio_url(request: UpdateFromBabelioUrlRequest) -> JSONR
             item_id=request.item_id,
             babelio_url=request.babelio_url,
             item_type=request.item_type,
+            babelio_cookies=request.babelio_cookies,
         )
 
         if result["success"]:

--- a/src/back_office_lmelp/services/babelio_migration_service.py
+++ b/src/back_office_lmelp/services/babelio_migration_service.py
@@ -718,7 +718,11 @@ class BabelioMigrationService:
         }
 
     async def update_from_babelio_url(
-        self, item_id: str, babelio_url: str, item_type: str = "livre"
+        self,
+        item_id: str,
+        babelio_url: str,
+        item_type: str = "livre",
+        babelio_cookies: str | None = None,
     ) -> dict[str, Any]:
         """Met à jour un livre/auteur depuis une URL Babelio manuelle.
 
@@ -728,6 +732,9 @@ class BabelioMigrationService:
             item_id: ID du livre ou auteur MongoDB
             babelio_url: URL Babelio complète
             item_type: Type d'item ('livre' ou 'auteur')
+            babelio_cookies: Valeur du header Cookie copiée depuis les DevTools du
+                navigateur sur babelio.com. Permet de contourner le captcha Babelio
+                (Issue #251).
 
         Returns:
             Dict avec success, scraped_data, ou error
@@ -746,10 +753,10 @@ class BabelioMigrationService:
             if item_type == "livre":
                 # Scraper les données de la page livre
                 titre = await self.babelio_service.fetch_full_title_from_url(
-                    babelio_url
+                    babelio_url, babelio_cookies=babelio_cookies
                 )
                 auteur_url = await self.babelio_service.fetch_author_url_from_page(
-                    babelio_url
+                    babelio_url, babelio_cookies=babelio_cookies
                 )
 
                 if not titre:

--- a/src/back_office_lmelp/services/babelio_service.py
+++ b/src/back_office_lmelp/services/babelio_service.py
@@ -37,6 +37,14 @@ from bs4 import BeautifulSoup
 logger = logging.getLogger(__name__)
 
 
+class BabelioBlockedError(Exception):
+    """Levée quand Babelio renvoie HTTP 403 (blocage anti-bot).
+
+    Distingue un blocage anti-bot d'un "vraiment pas trouvé sur Babelio" (Issue #251).
+    Le cookie jstsToken (TTL ~5 min) est probablement manquant ou expiré.
+    """
+
+
 class BabelioService:
     """Service de vérification orthographique via l'API AJAX de Babelio.
 
@@ -126,7 +134,7 @@ class BabelioService:
         return {
             "Content-Type": "application/json",
             "Accept": "application/json, text/javascript, */*; q=0.01",
-            "User-Agent": "Mozilla/5.0 (X11; Ubuntu; Linux x86_64; rv:142.0) Gecko/20100101 Firefox/142.0",
+            "User-Agent": "Mozilla/5.0 (X11; Ubuntu; Linux x86_64; rv:151.0) Gecko/20100101 Firefox/151.0",
             "X-Requested-With": "XMLHttpRequest",
             "Referer": "https://www.babelio.com/recherche.php",
             "Origin": "https://www.babelio.com",
@@ -161,7 +169,7 @@ class BabelioService:
             Dict de headers HTTP à utiliser dans aiohttp.ClientSession.
         """
         headers: dict[str, str] = {
-            "User-Agent": "Mozilla/5.0 (X11; Ubuntu; Linux x86_64; rv:142.0) Gecko/20100101 Firefox/142.0",
+            "User-Agent": "Mozilla/5.0 (X11; Ubuntu; Linux x86_64; rv:151.0) Gecko/20100101 Firefox/151.0",
             "Accept": "text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8",
             "Accept-Language": "fr,en-US;q=0.7,en;q=0.3",
             "Referer": "https://www.babelio.com/",
@@ -214,6 +222,11 @@ class BabelioService:
                 ) as tmp_session,
                 tmp_session.get(url) as response,
             ):
+                if response.status == 403:
+                    logger.warning(
+                        f"Babelio HTTP 403 pour scraping page: {url} - cookie requis"
+                    )
+                    raise BabelioBlockedError(f"Babelio 403 scraping: {url}")
                 if response.status != 200:
                     logger.warning(
                         f"Babelio HTTP {response.status} pour scraping page: {url}"
@@ -417,6 +430,9 @@ class BabelioService:
                             logger.error(f"Content-Type: {content_type}")
                             logger.error(f"Début: {text_content[:200]}...")
                             return []
+                    elif response.status == 403:
+                        logger.warning(f"Babelio HTTP 403 pour: {term} - cookie requis")
+                        raise BabelioBlockedError(f"Babelio 403: {term}")
                     elif response.status == 503:
                         logger.warning(
                             f"Babelio HTTP 503 (Service Unavailable) pour: {term} - rate limited"
@@ -426,6 +442,9 @@ class BabelioService:
                         logger.warning(f"Babelio HTTP {response.status} pour: {term}")
                         return []
 
+            except BabelioBlockedError:
+                # Propager pour que verify_author/verify_book signalent le blocage
+                raise
             except TimeoutError as e:
                 logger.error(f"Timeout Babelio pour: {term}")
                 # Propager l'erreur pour que l'appelant sache qu'il y a eu un problème réseau
@@ -504,6 +523,19 @@ class BabelioService:
                 "error_message": None,
             }
 
+        except BabelioBlockedError:
+            return {
+                "status": "blocked_403",
+                "original": author_name,
+                "babelio_suggestion": None,
+                "confidence_score": 0.0,
+                "babelio_data": None,
+                "babelio_url": None,
+                "error_message": (
+                    "Babelio a bloqué la requête (403). Le cookie jstsToken est "
+                    "probablement expiré — collez un cookie frais."
+                ),
+            }
         except (TimeoutError, aiohttp.ClientError):
             # Propager les erreurs réseau/timeout pour que le script de migration
             # puisse les détecter et arrêter le traitement
@@ -694,6 +726,8 @@ class BabelioService:
                     babelio_publisher = await self.fetch_publisher_from_url(
                         babelio_url, babelio_cookies=babelio_cookies
                     )
+                except BabelioBlockedError:
+                    raise
                 except Exception as e:
                     # Erreur de scraping non fatale, on continue sans éditeur
                     logger.debug(
@@ -710,6 +744,8 @@ class BabelioService:
                         suggested_title = full_title
                         # Mettre à jour aussi babelio_data pour le frontend (Issue #88)
                         babelio_data_clean["titre"] = full_title
+                except BabelioBlockedError:
+                    raise
                 except Exception as e:
                     # Erreur de scraping non fatale, on continue avec titre tronqué
                     logger.debug(
@@ -725,6 +761,8 @@ class BabelioService:
                     babelio_author_url = await self.fetch_author_url_from_page(
                         babelio_url, babelio_cookies=babelio_cookies
                     )
+                except BabelioBlockedError:
+                    raise
                 except Exception as e:
                     # Erreur de scraping non fatale, on continue sans URL auteur
                     logger.debug(
@@ -745,6 +783,22 @@ class BabelioService:
                 "error_message": None,
             }
 
+        except BabelioBlockedError:
+            return {
+                "status": "blocked_403",
+                "original_title": title,
+                "babelio_suggestion_title": None,
+                "original_author": author,
+                "babelio_suggestion_author": None,
+                "confidence_score": 0.0,
+                "babelio_data": None,
+                "babelio_url": None,
+                "babelio_author_url": None,
+                "error_message": (
+                    "Babelio a bloqué la requête (403). Le cookie jstsToken est "
+                    "probablement expiré — collez un cookie frais."
+                ),
+            }
         except (TimeoutError, aiohttp.ClientError):
             # Propager les erreurs réseau/timeout pour que le script de migration
             # puisse les détecter et arrêter le traitement
@@ -828,6 +882,8 @@ class BabelioService:
             logger.debug(f"Titre complet non trouvé pour {babelio_url}")
             return None
 
+        except BabelioBlockedError:
+            raise
         except Exception as e:
             logger.error(f"Erreur scraping titre pour {babelio_url}: {e}")
             return None
@@ -879,6 +935,8 @@ class BabelioService:
             logger.debug(f"Éditeur non trouvé pour {babelio_url}")
             return None
 
+        except BabelioBlockedError:
+            raise
         except Exception as e:
             logger.error(f"Erreur scraping éditeur pour {babelio_url}: {e}")
             return None
@@ -1293,6 +1351,8 @@ class BabelioService:
                 )
             return None
 
+        except BabelioBlockedError:
+            raise
         except Exception as e:
             logger.error(f"Erreur scraping URL auteur pour {babelio_url}: {e}")
             if self._debug_log_enabled:
@@ -1388,6 +1448,8 @@ class BabelioService:
                 )
             return None
 
+        except BabelioBlockedError:
+            raise
         except Exception as e:
             logger.error(
                 f"Erreur scraping auteur pour {babelio_url}: {e}", exc_info=True

--- a/tests/test_babelio_403_detection.py
+++ b/tests/test_babelio_403_detection.py
@@ -1,0 +1,207 @@
+"""Tests TDD pour la détection explicite des 403 Babelio (Issue #251).
+
+Problème identifié :
+- Quand Babelio renvoie 403 (anti-bot, cookie manquant/expiré), search() et
+  _fetch_page() loggaient un warning puis retournaient []/None — indistinguable
+  d'un "vraiment pas trouvé sur Babelio". L'utilisateur n'avait aucun signal
+  qu'il devait rafraîchir son cookie jstsToken.
+
+Solution :
+- Nouvelle exception BabelioBlockedError levée sur HTTP 403.
+- verify_author()/verify_book() la capturent et renvoient status='blocked_403'
+  au lieu de 'not_found', pour que le frontend puisse afficher une alerte
+  distincte de "livre non trouvé sur Babelio".
+"""
+
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from back_office_lmelp.services.babelio_service import (
+    BabelioBlockedError,
+    BabelioService,
+)
+
+
+@pytest.fixture
+def service():
+    return BabelioService()
+
+
+# ============================================================
+# 1. search() doit lever BabelioBlockedError sur 403
+# ============================================================
+
+
+@pytest.mark.asyncio
+async def test_search_raises_blocked_error_on_403(service):
+    """search() doit lever BabelioBlockedError si Babelio renvoie 403."""
+
+    class FakeResponse:
+        status = 403
+
+        async def text(self, encoding=None):
+            return ""
+
+        async def __aenter__(self):
+            return self
+
+        async def __aexit__(self, *args):
+            pass
+
+    class FakeSession:
+        def post(self, url, **kwargs):
+            return FakeResponse()
+
+        async def close(self):
+            pass
+
+        @property
+        def closed(self):
+            return False
+
+    with (
+        patch.object(
+            service, "_get_session", new=AsyncMock(return_value=FakeSession())
+        ),
+        pytest.raises(BabelioBlockedError),
+    ):
+        await service.search("Boualem Sansal")
+
+
+@pytest.mark.asyncio
+async def test_search_still_returns_empty_for_non_403_errors(service):
+    """search() doit toujours retourner [] pour les erreurs non-403 (503, etc.)."""
+
+    class FakeResponse:
+        status = 503
+
+        async def text(self, encoding=None):
+            return ""
+
+        async def __aenter__(self):
+            return self
+
+        async def __aexit__(self, *args):
+            pass
+
+    class FakeSession:
+        def post(self, url, **kwargs):
+            return FakeResponse()
+
+        async def close(self):
+            pass
+
+        @property
+        def closed(self):
+            return False
+
+    with patch.object(
+        service, "_get_session", new=AsyncMock(return_value=FakeSession())
+    ):
+        result = await service.search("Boualem Sansal")
+
+    assert result == []
+
+
+# ============================================================
+# 2. _fetch_page() doit lever BabelioBlockedError sur 403
+# ============================================================
+
+
+@pytest.mark.asyncio
+async def test_fetch_page_raises_blocked_error_on_403(service):
+    """_fetch_page doit lever BabelioBlockedError si Babelio renvoie 403."""
+    mock_response = MagicMock()
+    mock_response.status = 403
+
+    mock_session = MagicMock()
+    mock_session.__aenter__ = AsyncMock(return_value=mock_session)
+    mock_session.__aexit__ = AsyncMock(return_value=None)
+    mock_session.get = MagicMock()
+    mock_session.get.return_value.__aenter__ = AsyncMock(return_value=mock_response)
+    mock_session.get.return_value.__aexit__ = AsyncMock(return_value=None)
+
+    with (
+        patch("aiohttp.ClientSession", return_value=mock_session),
+        pytest.raises(BabelioBlockedError),
+    ):
+        await service._fetch_page("https://www.babelio.com/livres/Test/1")
+
+
+@pytest.mark.asyncio
+async def test_fetch_page_still_returns_none_for_non_403_errors(service):
+    """_fetch_page doit toujours retourner None pour les erreurs non-403."""
+    mock_response = MagicMock()
+    mock_response.status = 503
+
+    mock_session = MagicMock()
+    mock_session.__aenter__ = AsyncMock(return_value=mock_session)
+    mock_session.__aexit__ = AsyncMock(return_value=None)
+    mock_session.get = MagicMock()
+    mock_session.get.return_value.__aenter__ = AsyncMock(return_value=mock_response)
+    mock_session.get.return_value.__aexit__ = AsyncMock(return_value=None)
+
+    with patch("aiohttp.ClientSession", return_value=mock_session):
+        result = await service._fetch_page("https://www.babelio.com/livres/Test/1")
+
+    assert result is None
+
+
+# ============================================================
+# 3. verify_author()/verify_book() doivent renvoyer status='blocked_403'
+# ============================================================
+
+
+@pytest.mark.asyncio
+async def test_verify_author_returns_blocked_403_status(service):
+    """verify_author() doit renvoyer status='blocked_403' quand search() est bloqué."""
+    with patch.object(
+        service, "search", new=AsyncMock(side_effect=BabelioBlockedError("403"))
+    ):
+        result = await service.verify_author("Boualem Sansal")
+
+    assert result["status"] == "blocked_403"
+    assert result["original"] == "Boualem Sansal"
+    assert result["error_message"] is not None
+
+
+@pytest.mark.asyncio
+async def test_verify_book_returns_blocked_403_status(service):
+    """verify_book() doit renvoyer status='blocked_403' quand search() est bloqué."""
+    with patch.object(
+        service, "search", new=AsyncMock(side_effect=BabelioBlockedError("403"))
+    ):
+        result = await service.verify_book("La Légende", "Boualem Sansal")
+
+    assert result["status"] == "blocked_403"
+    assert result["original_title"] == "La Légende"
+    assert result["error_message"] is not None
+
+
+@pytest.mark.asyncio
+async def test_verify_book_returns_blocked_403_when_scraping_blocked(service):
+    """verify_book() doit renvoyer status='blocked_403' si search() réussit mais
+    le scraping de la page livre (fetch_author_url_from_page) est bloqué par Babelio.
+    """
+    book_result = {
+        "type": "livres",
+        "titre": "Murmuration",
+        "nom": "Silhol",
+        "prenoms": "Léa",
+        "url": "/livres/Silhol-Murmuration/12345",
+        "ca_copies": "10",
+        "ca_note": "4.0",
+    }
+
+    with (
+        patch.object(service, "search", new=AsyncMock(return_value=[book_result])),
+        patch.object(
+            service,
+            "fetch_author_url_from_page",
+            new=AsyncMock(side_effect=BabelioBlockedError("403 scraping")),
+        ),
+    ):
+        result = await service.verify_book("Murmuration", "Léa Silhol")
+
+    assert result["status"] == "blocked_403"

--- a/tests/test_babelio_cookies_propagation.py
+++ b/tests/test_babelio_cookies_propagation.py
@@ -77,9 +77,11 @@ async def test_fetch_page_returns_html_on_success(service):
 
 @pytest.mark.asyncio
 async def test_fetch_page_returns_none_on_non_200(service):
-    """_fetch_page doit retourner None si le statut HTTP n'est pas 200."""
+    """_fetch_page doit retourner None si le statut HTTP n'est pas 200 (hors 403,
+    qui a son propre comportement dédié — voir test_babelio_403_detection.py).
+    """
     mock_response = MagicMock()
-    mock_response.status = 403
+    mock_response.status = 503
 
     mock_session = MagicMock()
     mock_session.__aenter__ = AsyncMock(return_value=mock_session)

--- a/tests/test_update_from_babelio_url.py
+++ b/tests/test_update_from_babelio_url.py
@@ -67,10 +67,10 @@ class TestUpdateFromBabelioUrl:
 
         # Vérifier l'appel au scraping
         mock_babelio_service.fetch_full_title_from_url.assert_called_once_with(
-            "https://www.babelio.com/livres/auteur/titre/123456"
+            "https://www.babelio.com/livres/auteur/titre/123456", babelio_cookies=None
         )
         mock_babelio_service.fetch_author_url_from_page.assert_called_once_with(
-            "https://www.babelio.com/livres/auteur/titre/123456"
+            "https://www.babelio.com/livres/auteur/titre/123456", babelio_cookies=None
         )
 
         # Vérifier la réutilisation de accept_suggestion
@@ -203,6 +203,49 @@ class TestUpdateFromBabelioUrl:
         # Assert
         assert result["success"] is False
         assert "error" in result
+
+    @pytest.mark.asyncio
+    async def test_should_propagate_babelio_cookies_to_scraping_calls(self):
+        """Test TDD (Issue #251): update_from_babelio_url doit propager
+        babelio_cookies aux appels de scraping, sinon Babelio renvoie 403
+        même quand l'utilisateur a fourni un cookie valide dans l'UI.
+        """
+        from back_office_lmelp.services.babelio_migration_service import (
+            BabelioMigrationService,
+        )
+
+        mock_mongodb_service = MagicMock()
+        mock_babelio_service = MagicMock()
+        mock_mongodb_service.db = MagicMock()
+
+        mock_babelio_service.fetch_full_title_from_url = AsyncMock(
+            return_value="Le Titre Correct"
+        )
+        mock_babelio_service.fetch_author_url_from_page = AsyncMock(
+            return_value="https://www.babelio.com/auteur/Nom-Auteur/12345"
+        )
+
+        service = BabelioMigrationService(mock_mongodb_service, mock_babelio_service)
+        service.accept_suggestion = MagicMock(return_value=True)
+
+        livre_id = str(ObjectId())
+        cookies = "jstsToken=abc123; p=FR; disclaimer=1"
+
+        await service.update_from_babelio_url(
+            item_id=livre_id,
+            babelio_url="https://www.babelio.com/livres/auteur/titre/123456",
+            item_type="livre",
+            babelio_cookies=cookies,
+        )
+
+        mock_babelio_service.fetch_full_title_from_url.assert_called_once_with(
+            "https://www.babelio.com/livres/auteur/titre/123456",
+            babelio_cookies=cookies,
+        )
+        mock_babelio_service.fetch_author_url_from_page.assert_called_once_with(
+            "https://www.babelio.com/livres/auteur/titre/123456",
+            babelio_cookies=cookies,
+        )
 
     @pytest.mark.asyncio
     async def test_should_return_error_if_item_not_found(self):

--- a/tests/test_update_from_url_endpoint.py
+++ b/tests/test_update_from_url_endpoint.py
@@ -71,6 +71,7 @@ class TestUpdateFromUrlEndpoint:
                 item_id=livre_id,
                 babelio_url="https://www.babelio.com/livres/auteur/titre/123456",
                 item_type="livre",
+                babelio_cookies=None,
             )
 
     def test_should_update_auteur_from_url_via_api(self, client):
@@ -177,6 +178,46 @@ class TestUpdateFromUrlEndpoint:
                 item_id=livre_id,
                 babelio_url="https://www.babelio.com/livres/auteur/titre/123",
                 item_type="livre",  # Valeur par défaut
+                babelio_cookies=None,
+            )
+
+    def test_should_pass_babelio_cookies_to_service(self, client):
+        """Test TDD (Issue #251): l'endpoint doit transmettre babelio_cookies
+        au service, sinon Babelio bloque les requêtes en 403 malgré le cookie
+        fourni par l'utilisateur dans l'UI.
+        """
+        livre_id = str(ObjectId())
+        cookies = "jstsToken=abc123; p=FR; disclaimer=1"
+
+        with patch(
+            "back_office_lmelp.app.babelio_migration_service"
+        ) as mock_migration_service:
+            mock_migration_service.update_from_babelio_url = AsyncMock(
+                return_value={
+                    "success": True,
+                    "scraped_data": {
+                        "titre": "Titre",
+                        "url_babelio": "https://www.babelio.com/livres/auteur/titre/123",
+                    },
+                }
+            )
+
+            response = client.post(
+                "/api/babelio-migration/update-from-url",
+                json={
+                    "item_id": livre_id,
+                    "babelio_url": "https://www.babelio.com/livres/auteur/titre/123",
+                    "item_type": "livre",
+                    "babelio_cookies": cookies,
+                },
+            )
+
+            assert response.status_code == 200
+            mock_migration_service.update_from_babelio_url.assert_called_once_with(
+                item_id=livre_id,
+                babelio_url="https://www.babelio.com/livres/auteur/titre/123",
+                item_type="livre",
+                babelio_cookies=cookies,
             )
 
     def test_should_return_400_on_scraping_failure(self, client):


### PR DESCRIPTION
## Summary

- Diagnosed live (devcontainer + VPN) that the jstsToken cookie mechanism from #247 still works correctly — 403s only occur when the cookie is missing or expired (~5min TTL). The real gap was UX/observability, not the propagation mechanism itself.
- Backend: new `BabelioBlockedError` raised on HTTP 403 in `search()`/`_fetch_page()`, caught in `verify_author()`/`verify_book()` to return `status='blocked_403'` instead of a misleading `not_found`.
- Frontend `LivresAuteurs.vue`: red banner shown when a 403 block is detected, a save confirmation message, and a "likely expired" badge after 5 minutes.
- Found and fixed a separate bug during manual testing: `BabelioMigration.vue`'s manual URL update (`update_from_babelio_url`) had **no cookie propagation at all** in the chain (service → endpoint → frontend), so it silently 403'd even with a valid cookie configured.
- Aligned `BabelioMigration.vue`'s cookie UI with `LivresAuteurs.vue` (explicit Enregistrer/Effacer buttons instead of auto-save-on-input) and moved the cookie block to the top of the page, per user request during manual testing.
- Filed #252 separately for unrelated slow/flaky RadioFrance network tests discovered while running the full suite.

## Test plan

- [x] Backend TDD: `tests/test_babelio_403_detection.py` (7 new tests covering `BabelioBlockedError` propagation through `search()`, `_fetch_page()`, `verify_author()`, `verify_book()`, including the nested-scraping-call edge case)
- [x] Backend: `tests/test_update_from_babelio_url.py` + `tests/test_update_from_url_endpoint.py` updated/extended for cookie propagation in the migration flow
- [x] Frontend: `frontend/tests/integration/LivresAuteurs.babelio403.test.js` (9 tests — banner, save confirmation, expiry badge)
- [x] Frontend: `frontend/tests/BabelioMigration.cookieButtons.test.js` + `BabelioMigration.cookiePropagation.test.js` (7 tests)
- [x] Full backend suite: 1387 passed, 23 skipped, 0 failed
- [x] Full frontend suite: 645 passed, 14 skipped, 0 failed
- [x] `ruff check`, `ruff format`, `mypy src/` clean
- [x] `mkdocs build --strict` clean
- [x] Manual end-to-end verification in devcontainer (with VPN, same IP as server) on both LivresAuteurs and BabelioMigration pages — confirmed by user ("c'est parfait")
- [x] CI/CD pipeline green (security, test 3.11/3.12, frontend-tests, integration-tests, quality-gate)

🤖 Generated with [Claude Code](https://claude.com/claude-code)